### PR TITLE
feat: Update font to Cica and migrate Neovim to mini.nvim

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -1,0 +1,27 @@
+-- Initialize mini.nvim
+-- IMPORTANT: See init.lua section of `mini.nvim` :help for what to do here
+local minipath = vim.fn.stdpath('data') .. '/mini'
+if not vim.loop.fs_stat(minipath .. '/lua/mini.nvim') then
+  local clone_cmd = {
+    'git', 'clone', '--filter=blob:none',
+    'https://github.com/echasnovski/mini.nvim', minipath
+  }
+  -- Use this instead if you want to control version of `mini.nvim`
+  -- local clone_cmd = {
+  --   'git', 'clone', '--filter=blob:none', '--branch', 'stable',
+  --   'https://github.com/echasnovski/mini.nvim', minipath
+  -- }
+  print('Cloning `mini.nvim` from GitHub...')
+  vim.fn.system(clone_cmd)
+  print('Done.')
+end
+vim.opt.rtp:prepend(minipath)
+
+-- Load plugin configuration
+require('plugins')
+
+-- Load options
+require('options')
+
+-- Load keymaps
+require('keymaps')

--- a/.config/nvim/lua/keymaps.lua
+++ b/.config/nvim/lua/keymaps.lua
@@ -1,0 +1,18 @@
+-- Keymappings
+vim.keymap.set('n', '<Leader>w', '<cmd>write<cr>', { desc = 'Save file' })
+vim.keymap.set('n', '<Leader>q', '<cmd>quit<cr>', { desc = 'Quit Neovim' })
+
+-- Setup which-key.nvim
+-- This should be called after which-key is loaded.
+-- Assuming mini.deps has loaded it by the time this file is required.
+local status_ok, which_key = pcall(require, "which-key")
+if not status_ok then
+  vim.notify("Failed to load which-key", vim.log.levels.WARN)
+  return
+end
+
+which_key.setup({
+  -- your configuration comes here
+  -- or leave it empty to use the default settings
+  -- refer to the configuration section for more details
+})

--- a/.config/nvim/lua/options.lua
+++ b/.config/nvim/lua/options.lua
@@ -1,0 +1,66 @@
+-- Set <space> as the leader key
+-- See `:help mapleader`
+--  NOTE: Must happen before plugins are required (otherwise wrong leader will be used)
+vim.g.mapleader = ' '
+vim.g.maplocalleader = ' '
+
+-- Setup mini.hues for theming
+-- This replaces the previous `vim.cmd.colorscheme 'tokyonight'`
+require('mini.hues').setup({
+  background = '#1e1e2e', -- A slightly bluish dark background (Catppuccin Macchiato base)
+  foreground = '#cdd6f4', -- Catppuccin Macchiato text
+
+  -- Palette for a futuristic look with vibrant accents
+  -- Using Catppuccin Macchiato palette as a base for a cohesive, modern feel
+  palette = {
+    -- Base colors
+    base = '#1e1e2e',     -- Background
+    surface0 = '#313244', -- Slightly lighter background for UI elements
+    surface1 = '#45475a', -- Even lighter for hovered items, etc.
+    surface2 = '#585b70',
+    overlay0 = '#6c7086',
+    overlay1 = '#7f849c',
+    overlay2 = '#9399b2',
+    text = '#cdd6f4',     -- Main foreground
+    subtext0 = '#a6adc8',
+    subtext1 = '#bac2de',
+
+    -- Accents (using Catppuccin's vibrant colors)
+    rosewater = '#f5e0dc',
+    flamingo = '#f2cdcd',
+    pink = '#f5c2e7',
+    mauve = '#cba6f7',    -- Primary accent - a vibrant purple/magenta
+    red = '#f38ba8',
+    maroon = '#eba0ac',
+    peach = '#fab387',
+    yellow = '#f9e2af',
+    green = '#a6e3a1',
+    teal = '#94e2d5',
+    sky = '#89dceb',      -- Secondary accent - a bright cyan
+    sapphire = '#74c7ec',
+    blue = '#89b4fa',     -- Tertiary accent - a nice blue
+    lavender = '#b4befe',
+  },
+
+  -- Define which palette color to use for `accent`
+  -- Let's use 'mauve' (a vibrant purple) as the primary accent
+  accent = 'mauve',
+
+  -- Automatically start and apply the theme
+  autostart = true
+})
+
+
+-- [[ Basic Autocommands ]]
+--  See `:help lua-guide-autocommands`
+
+-- Highlight when yanking (copying) text
+--  Try it with `yap` in normal mode
+--  See `:help vim.highlight.on_yank()`
+vim.api.nvim_create_autocmd('TextYankPost', {
+  desc = 'Highlight when yanking (copying) text',
+  group = vim.api.nvim_create_augroup('kickstart-highlight-yank', { clear = true }),
+  callback = function()
+    vim.highlight.on_yank()
+  end,
+})

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -1,0 +1,34 @@
+-- Initialize mini.deps
+-- It's automatically initialized if `mini.nvim` is set up,
+-- so we can directly use it.
+local add = require('mini.deps').add
+
+-- Add plugins
+-- mini.nvim modules like mini.hues are part of the main mini.nvim plugin,
+-- so no need to add them separately here if mini.nvim is already loaded.
+
+add('RRethy/vim-illuminate')
+
+add({
+  source = 'nvim-orgmode/orgmode',
+  -- Assuming mini.deps handles dependencies like treesitter if specified in orgmode's setup,
+  -- or if orgmode is updated to use package.module notation for dependencies.
+  -- For now, we'll keep it simple. Orgmode might need further config after this.
+})
+
+add('folke/which-key.nvim')
+
+-- Ensure plugins are setup/loaded.
+-- This might be implicitly handled by mini.deps or might need an explicit call.
+-- According to mini.nvim docs, `require('mini.deps').setup()` is optional
+-- and primarily for setting path.package.
+-- Plugins are typically loaded on demand or as configured.
+-- We will rely on the default behavior for now.
+
+-- `folke/which-key.nvim` might need its setup function called here
+-- or in keymaps.lua after it's loaded.
+-- For now, let's assume its config in keymaps.lua (if any) handles this.
+
+-- No need to add folke/tokyonight.nvim as we're switching to mini.hues.
+-- No need to add echasnovski/mini.nvim or echasnovski/mini.hues separately
+-- as mini.nvim is loaded from init.lua and includes mini.hues.

--- a/.config/wezterm/wezterm.lua
+++ b/.config/wezterm/wezterm.lua
@@ -1,0 +1,38 @@
+-- Pull in the wezterm API
+local wezterm = require 'wezterm'
+
+-- This table will hold the configuration.
+local config = {}
+
+-- In newer versions of wezterm, use the config_builder which will
+-- help provide clearer error messages
+if wezterm.config_builder then
+  config = wezterm.config_builder()
+end
+
+-- Font configuration
+config.font = wezterm.font 'Cica'
+config.font_size = 12.0
+
+-- Color scheme
+config.color_scheme = 'Gruvbox Dark'
+
+-- Keybindings
+config.keys = {
+  {
+    key = 'C',
+    mods = 'CTRL|SHIFT',
+    action = wezterm.action.CopyTo 'ClipboardAndPrimarySelection',
+  },
+  {
+    key = 'V',
+    mods = 'CTRL|SHIFT',
+    action = wezterm.action.PasteFrom 'Clipboard',
+  },
+}
+
+-- For example, changing the look and feel of the tabs
+config.use_fancy_tab_bar = false
+
+-- and finally, return the configuration to wezterm
+return config

--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
 # dotfiles
+
+This repository contains personal configuration files for various tools.
+
+## Wezterm
+
+This configuration sets up the [Wezterm](https://wezfurlong.org/wezterm/) terminal emulator with:
+- Cica font
+- Gruvbox Dark color scheme
+- Ctrl+Shift+C for copy, Ctrl+Shift+V for paste
+
+### Installation
+
+1.  **Install Wezterm**: Follow the instructions on the [official Wezterm installation page](https://wezfurlong.org/wezterm/installation.html).
+2.  **Install Cica font**: Download the latest release of "Cica" font from the [official GitHub repository](https://github.com/miiton/Cica/releases/latest). Extract the archive and install the font files (e.g., by moving them to `~/.local/share/fonts` on Linux or `~/Library/Fonts` on macOS, or by using your system's font installer). Ensure it's available to your system.
+3.  **Place the configuration file**:
+    ```bash
+    mkdir -p ~/.config/wezterm
+    cp .config/wezterm/wezterm.lua ~/.config/wezterm/
+    ```
+    (If you use a different `$XDG_CONFIG_HOME`, replace `~/.config` accordingly).
+
+## Neovim
+
+This configuration sets up [Neovim](https://neovim.io/) with:
+- `mini.nvim` (specifically `mini.deps`) for plugin management.
+- A custom dark, futuristic theme via `mini.hues` (part of `mini.nvim`).
+- Basic keymappings (e.g., `<Space>w` to save, `<Space>q` to quit).
+
+### Installation
+
+1.  **Install Neovim**: Follow the instructions on the [official Neovim installation page](https://github.com/neovim/neovim/wiki/Installing-Neovim). Version 0.8+ is recommended.
+2.  **Install `git`**: `mini.nvim` and its module `mini.deps` use `git` to clone and manage plugins. If you don't have it, install it using your system's package manager (e.g., `sudo apt install git` on Debian/Ubuntu, `brew install git` on macOS).
+3.  **Place the configuration file**:
+    ```bash
+    mkdir -p ~/.config/nvim
+    cp .config/nvim/init.lua ~/.config/nvim/
+    # If you want to copy the entire lua subdirectory as well:
+    # cp -r .config/nvim/lua ~/.config/nvim/
+    ```
+    (If you use a different `$XDG_CONFIG_HOME`, replace `~/.config` accordingly).
+    The main configuration file is `init.lua`. It includes a script to install `mini.nvim` itself. It then loads modularized settings from files located in the `.config/nvim/lua/` directory (e.g., `plugins.lua` for plugin management using `mini.deps`, `options.lua` for editor settings and `mini.hues` theme configuration, and `keymaps.lua` for keybindings). You'll need to copy the `lua` subdirectory as well if you are copying files manually.
+4.  **Install plugins**: `mini.nvim` itself is cloned and installed by a script in `init.lua` the first time you launch Neovim. Other plugins, managed by `mini.deps` (as defined in `lua/plugins.lua`), are typically installed automatically when Neovim starts and detects they are missing. You can also use commands provided by `mini.deps` if you need to manage dependencies manually (refer to `mini.deps` documentation for details).


### PR DESCRIPTION
This commit introduces two main changes:
1. Updates the Wezterm font from Fira Code to Cica.
2. Migrates your Neovim configuration from lazy.nvim to mini.nvim.

Wezterm:
- `.config/wezterm/wezterm.lua` now specifies 'Cica' as the font.
- `README.md` updated with instructions for installing the Cica font.

Neovim:
- Replaced `lazy.nvim` with `mini.nvim` for a more lightweight setup.
  - `mini.deps` is now used for plugin management in `lua/plugins.lua`.
  - `mini.nvim` itself is installed via a snippet in `init.lua`.
- Theming is now handled by `mini.hues` (part of `mini.nvim`).
  - A custom dark, futuristic theme (Catppuccin Macchiato based) is configured in `lua/options.lua`.
- `folke/which-key.nvim` setup is explicitly called in `lua/keymaps.lua`.
- `README.md` has been updated to reflect these changes, including new setup instructions for `mini.nvim`.