### PR TITLE
feat(lazygit): Add lazygit configuration and integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A comprehensive, XDG-compliant dotfiles repository with modular tool configurati
 - **[proto/](proto/)** - Multi-language toolchain manager
 - **[docker/](docker/)** - Containerization platform setup
 - **[git/](git/)** - Version control with delta for better diffs
+- **[lazygit/](lazygit/)** - Terminal UI for git commands
 
 ### CLI Utilities
 - **[eza/](eza/)** - Modern replacement for ls
@@ -86,7 +87,7 @@ dotfiles/
 ├── zsh/                    # Zsh configuration
 │   ├── .zshenv            # Zsh environment file (links to ~/.zshenv)
 │   ├── .zshrc             # Main Zsh configuration
-│   ├── aliases.zsh        # Shell aliases
+│   ├── abbreviations.zsh  # Shell abbreviations (via zsh-abbr)
 │   ├── functions.zsh      # Custom functions
 │   ├── env.zsh            # Environment variables
 │   └── install.sh         # Zsh installation script
@@ -96,6 +97,10 @@ dotfiles/
 │   ├── ignore             # Global gitignore
 │   ├── attributes         # Git attributes
 │   └── install.sh         # Git installation script
+│
+├── lazygit/                # Lazygit configuration
+│   ├── config.yml         # Lazygit configuration
+│   └── install.sh         # Lazygit installation script
 │
 ├── nvim/                   # Neovim configuration
 │   ├── init.lua           # Neovim configuration with mini.nvim

--- a/install.sh
+++ b/install.sh
@@ -74,6 +74,7 @@ install_all_tools() {
         "homebrew"
         "zsh"
         "git"
+        "lazygit"
         "starship"
         "sheldon"
         "nvim"

--- a/lazygit/config.yml
+++ b/lazygit/config.yml
@@ -1,0 +1,305 @@
+# Lazygit configuration
+# See: https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md
+
+gui:
+  # Theme
+  theme:
+    lightTheme: false
+    activeBorderColor:
+      - '#89b4fa' # Catppuccin blue
+      - bold
+    inactiveBorderColor:
+      - '#45475a' # Catppuccin surface1
+    searchingActiveBorderColor:
+      - '#f9e2af' # Catppuccin yellow
+      - bold
+    optionsTextColor:
+      - '#89b4fa' # Catppuccin blue
+    selectedLineBgColor:
+      - '#313244' # Catppuccin surface0
+    selectedRangeBgColor:
+      - '#313244' # Catppuccin surface0
+    cherryPickedCommitBgColor:
+      - '#94e2d5' # Catppuccin teal
+    cherryPickedCommitFgColor:
+      - '#89b4fa' # Catppuccin blue
+    unstagedChangesColor:
+      - '#f38ba8' # Catppuccin red
+    defaultFgColor:
+      - '#cdd6f4' # Catppuccin text
+
+  # Window settings
+  windowSize: 'normal' # one of 'normal' | 'half' | 'full'
+  scrollHeight: 2
+  scrollPastBottom: true
+  scrollOffMargin: 2
+  scrollOffBehavior: 'margin' # one of 'margin' | 'jump'
+  sidePanelWidth: 0.3333
+  expandFocusedSidePanel: false
+  mainPanelSplitMode: 'flexible' # one of 'horizontal' | 'flexible' | 'vertical'
+  enlargedSideViewLocation: 'left' # one of 'left' | 'top'
+  language: 'auto' # one of 'auto' | 'en' | 'zh' | 'pl' | 'nl' | 'ja' | 'ko'
+  timeFormat: '02 Jan 06 15:04 MST'
+  shortTimeFormat: '15:04'
+  
+  # Display settings
+  showListFooter: true
+  showFileTree: true
+  showRandomTip: false
+  showBranchCommitHash: false
+  showBottomLine: true
+  showCommandLog: true
+  showIcons: true
+  commandLogSize: 8
+  splitDiff: 'auto' # one of 'auto' | 'always'
+  skipUnstageLineWarning: false
+  skipStashWarning: false
+  skipNoStagedFilesWarning: false
+  skipRewordInEditorWarning: false
+  
+  # Commit message length
+  commitLength:
+    show: true
+  
+  # Mouse support
+  mouseEvents: true
+  
+  # File editing
+  skipHookPrefix: WIP
+  
+  # Border style
+  border: 'single' # one of 'single' | 'double' | 'rounded' | 'hidden'
+  
+  # Animations
+  animateExplosion: true
+
+git:
+  # Paging
+  paging:
+    colorArg: always
+    pager: delta --dark --paging=never
+    useConfig: false
+    externalDiffCommand: ''
+
+  # Commit settings
+  commit:
+    signOff: false
+    verbose: 'default' # one of 'default' | 'always' | 'never'
+    
+  # Merging
+  merging:
+    manualCommit: false
+    args: ''
+    
+  # Logging
+  log:
+    order: 'topo-order' # one of 'date-order' | 'author-date-order' | 'topo-order' | 'default'
+    showGraph: 'when-maximised' # one of 'always' | 'never' | 'when-maximised'
+    showWholeGraph: false
+    
+  # Skipping
+  skipHookPrefix: WIP
+  autoFetch: true
+  autoRefresh: true
+  fetchAll: true # Pass --all flag when running git fetch
+  branchLogCmd: 'git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --'
+  allBranchesLogCmd: 'git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium'
+  overrideGpg: false # prevents lazygit from spawning a separate process when using GPG
+  disableForcePushing: false
+  parseEmoji: false
+  diffContextSize: 3 # how many lines of context are shown around a change in diffs
+  
+  # Checkout behavior
+  truncateCopiedCommitHashesTo: 12
+
+# Update checking
+update:
+  method: prompt # can be: prompt | background | never
+  days: 14 # how often an update is checked for
+
+# Confirmation for actions
+confirmOnQuit: false
+quitOnTopLevelReturn: false
+
+# Keybindings (using vim-style where possible)
+keybinding:
+  universal:
+    quit: 'q'
+    quit-alt1: '<c-c>' # alternative/alias of quit
+    return: '<esc>' # return to previous menu, will quit if there's nowhere to return
+    quitWithoutChangingDirectory: 'Q'
+    togglePanel: '<tab>' # goto the next panel
+    prevItem: '<up>' # go one line up
+    nextItem: '<down>' # go one line down
+    prevItem-alt: 'k' # go one line up
+    nextItem-alt: 'j' # go one line down
+    prevPage: ',' # go to next page in list
+    nextPage: '.' # go to previous page in list
+    gotoTop: '<' # go to top of list
+    gotoBottom: '>' # go to bottom of list
+    scrollLeft: 'H' # scroll left within list view
+    scrollRight: 'L' # scroll right within list view
+    prevBlock: '<left>' # goto the previous block / panel
+    nextBlock: '<right>' # goto the next block / panel
+    prevBlock-alt: 'h' # goto the previous block / panel
+    nextBlock-alt: 'l' # goto the next block / panel
+    jumpToBlock: ["1", "2", "3", "4", "5"] # goto the Nth block / panel
+    nextMatch: 'n'
+    prevMatch: 'N'
+    optionMenu: 'x' # show help menu
+    optionMenu-alt1: '?' # show help menu
+    select: '<space>'
+    goInto: '<enter>'
+    openRecentRepos: '<c-r>'
+    confirm: '<enter>'
+    remove: 'd'
+    new: 'n'
+    edit: 'e'
+    openFile: 'o'
+    scrollUpMain: '<pgup>' # main panel scroll up
+    scrollDownMain: '<pgdown>' # main panel scroll down
+    scrollUpMain-alt1: 'K' # main panel scroll up
+    scrollDownMain-alt1: 'J' # main panel scroll down
+    scrollUpMain-alt2: '<c-u>' # main panel scroll up
+    scrollDownMain-alt2: '<c-d>' # main panel scroll down
+    executeCustomCommand: ':'
+    createRebaseOptionsMenu: 'm'
+    pushFiles: 'P'
+    pullFiles: 'p'
+    refresh: 'R'
+    createPatchOptionsMenu: '<c-p>'
+    nextTab: ']'
+    prevTab: '['
+    nextScreenMode: '+'
+    prevScreenMode: '_'
+    undo: 'z'
+    redo: '<c-z>'
+    filteringMenu: '<c-s>'
+    diffingMenu: 'W'
+    diffingMenu-alt: '<c-e>' # deprecated
+    copyToClipboard: '<c-o>'
+    submitEditorText: '<enter>'
+    appendNewline: '<a-enter>'
+    extrasMenu: '@'
+    toggleWhitespaceInDiffView: '<c-w>'
+    increaseContextInDiffView: '}'
+    decreaseContextInDiffView: '{'
+    
+  status:
+    checkForUpdate: 'u'
+    recentRepos: '<enter>'
+    
+  files:
+    commitChanges: 'c'
+    commitChangesWithoutHook: 'w' # commit changes without pre-commit hook
+    amendLastCommit: 'A'
+    commitChangesWithEditor: 'C'
+    ignoreFile: 'i'
+    refreshFiles: 'r'
+    stashAllChanges: 's'
+    viewStashOptions: 'S'
+    toggleStagedAll: 'a' # stage/unstage all
+    viewResetOptions: 'D'
+    fetch: 'f'
+    toggleTreeView: '`'
+    openMergeTool: 'M'
+    openStatusFilter: '<c-b>'
+    
+  branches:
+    createPullRequest: 'o'
+    viewPullRequestOptions: 'O'
+    checkoutBranchByName: 'c'
+    forceCheckoutBranch: 'F'
+    rebaseBranch: 'r'
+    renameBranch: 'R'
+    mergeIntoCurrentBranch: 'M'
+    viewGitFlowOptions: 'i'
+    fastForward: 'f' # fast-forward this branch from its upstream
+    createTag: 'T'
+    pushTag: 'P'
+    setUpstream: 'u' # set as upstream of checked-out branch
+    fetchRemote: 'f'
+    
+  commits:
+    squashDown: 's'
+    renameCommit: 'r'
+    renameCommitWithEditor: 'R'
+    viewResetOptions: 'g'
+    markCommitAsFixup: 'f'
+    createFixupCommit: 'F' # create fixup commit for this commit
+    squashAboveCommits: 'S'
+    moveDownCommit: '<c-j>' # move commit down one
+    moveUpCommit: '<c-k>' # move commit up one
+    amendToCommit: 'A'
+    pickCommit: 'p' # pick commit (when mid-rebase)
+    revertCommit: 't'
+    cherryPickCopy: 'c'
+    cherryPickCopyRange: 'C'
+    pasteCommits: 'v'
+    tagCommit: 'T'
+    checkoutCommit: '<space>'
+    resetCherryPick: '<c-R>'
+    copyCommitMessageToClipboard: '<c-y>'
+    openLogMenu: '<c-l>'
+    viewBisectOptions: 'b'
+    
+  stash:
+    popStash: 'g'
+    renameStash: 'r'
+    
+  commitFiles:
+    checkoutCommitFile: 'c'
+    
+  main:
+    toggleDragSelect: 'v'
+    toggleDragSelect-alt: 'V'
+    toggleSelectHunk: 'a'
+    pickBothHunks: 'b'
+    
+  submodules:
+    init: 'i'
+    update: 'u'
+    bulkMenu: 'b'
+
+# OS specific configs
+os:
+  editPreset: 'nvim' # see 'Configuring File Editing' section
+  edit: 'nvim {{filename}}'
+  editAtLine: 'nvim +{{line}} {{filename}}'
+  editAtLineAndWait: 'nvim +{{line}} {{filename}}'
+  open: 'xdg-open {{filename}}'
+  openLink: 'xdg-open {{link}}'
+
+# Custom commands
+customCommands:
+  - key: 'C'
+    command: 'git cz'
+    description: 'commit with commitizen'
+    context: 'files'
+    loadingText: 'opening commitizen commit tool'
+    subprocess: true
+  - key: 'T'
+    command: 'git tag -a {{.Form.TagName}} -m "{{.Form.Message}}"'
+    description: 'Create annotated tag'
+    context: 'commits'
+    prompts:
+      - type: 'input'
+        title: 'Tag name'
+        key: 'TagName'
+      - type: 'input'
+        title: 'Tag message'
+        key: 'Message'
+  - key: '<c-t>'
+    command: 'git todo'
+    description: 'Add TODO comment'
+    context: 'files'
+    subprocess: true
+
+# Services (for creating PRs, issues, etc.)
+services:
+  'github.com': 'github.com'
+  'gitlab.com': 'gitlab.com'
+
+# Notifications
+notARepository: 'prompt' # one of: 'prompt' | 'create' | 'skip'
+promptToReturnFromSubprocess: true

--- a/lazygit/install.sh
+++ b/lazygit/install.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Lazygit installation script
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "Setting up Lazygit..."
+
+# Create XDG lazygit directory
+mkdir -p "$HOME/.config/lazygit"
+
+# Link lazygit configuration
+ln -sf "$SCRIPT_DIR/config.yml" "$HOME/.config/lazygit/config.yml"
+
+# Install lazygit if not present
+if ! command -v lazygit >/dev/null 2>&1; then
+    echo "Installing Lazygit..."
+    
+    if command -v brew >/dev/null 2>&1; then
+        # Install via Homebrew (preferred method)
+        brew install lazygit
+    elif command -v go >/dev/null 2>&1; then
+        # Install via Go
+        go install github.com/jesseduffield/lazygit@latest
+    else
+        # Install via GitHub releases
+        LAZYGIT_VERSION=$(curl -s "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+        
+        if [ -z "$LAZYGIT_VERSION" ]; then
+            echo "Failed to get Lazygit version. Please install manually."
+            echo "Visit: https://github.com/jesseduffield/lazygit#installation"
+            exit 1
+        fi
+        
+        # Determine architecture
+        ARCH=$(uname -m)
+        case $ARCH in
+            x86_64) ARCH="x86_64" ;;
+            aarch64|arm64) ARCH="arm64" ;;
+            *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
+        esac
+        
+        # Download and install
+        curl -Lo lazygit.tar.gz "https://github.com/jesseduffield/lazygit/releases/latest/download/lazygit_${LAZYGIT_VERSION#v}_Linux_${ARCH}.tar.gz"
+        tar xf lazygit.tar.gz lazygit
+        mkdir -p "$HOME/.local/bin"
+        install lazygit "$HOME/.local/bin"
+        rm lazygit.tar.gz lazygit
+        
+        echo "Lazygit installed to ~/.local/bin/lazygit"
+        echo "Make sure ~/.local/bin is in your PATH"
+    fi
+else
+    echo "Lazygit already installed"
+fi
+
+echo "Lazygit setup complete!"
+echo "Run 'lazygit' to start using it with the custom configuration"

--- a/zsh/abbreviations.zsh
+++ b/zsh/abbreviations.zsh
@@ -47,6 +47,11 @@ abbr "grs" "git reset"
 abbr "grsh" "git reset --hard"
 abbr "grss" "git reset --soft"
 
+# Lazygit abbreviations
+abbr "lg" "lazygit"
+abbr "lgs" "lazygit status"
+abbr "lgb" "lazygit log"
+
 # Docker abbreviations
 abbr "d" "docker"
 abbr "dc" "docker compose"


### PR DESCRIPTION
## Summary
- Add comprehensive lazygit configuration with Catppuccin theme
- Integrate lazygit into the modular dotfiles structure with install script
- Add zsh abbreviations for quick lazygit access

## Features Added
- **Catppuccin theme** matching other tools in the dotfiles
- **Vim-style keybindings** for consistent navigation
- **Delta integration** for enhanced git diff viewing
- **Custom commands** for commitizen and advanced git operations
- **Multiple installation methods** (Homebrew, Go, manual GitHub releases)
- **ZSH abbreviations**: `lg` → `lazygit`, `lgs` → `lazygit status`, `lgb` → `lazygit log`

## Installation
- Included in main install script: `./install.sh`
- Individual installation: `./lazygit/install.sh`
- Selective installation: `./install.sh lazygit`

## Test plan
- [ ] Install lazygit via install script
- [ ] Verify configuration is properly linked
- [ ] Test vim-style navigation in lazygit
- [ ] Confirm Catppuccin theme is applied
- [ ] Test abbreviations expand correctly

🤖 Generated with [Claude Code](https://claude.ai/code)