### PR TITLE
:wrench: fix(build): Add build tools requirement and helper script

### DIFF
--- a/install-build-tools.sh
+++ b/install-build-tools.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Build tools installation script
+# This script installs build essentials required for compiling Rust packages
+
+set -euo pipefail
+
+echo "Installing build tools..."
+
+# Check if already installed
+if command -v cc >/dev/null 2>&1; then
+    echo "Build tools already installed!"
+    echo "C compiler: $(which cc)"
+    exit 0
+fi
+
+# Install based on detected package manager
+if command -v apt-get >/dev/null 2>&1; then
+    echo "Detected Debian/Ubuntu system. Installing build-essential..."
+    sudo apt-get update && sudo apt-get install -y build-essential
+elif command -v yum >/dev/null 2>&1; then
+    echo "Detected CentOS/RHEL system. Installing Development Tools..."
+    sudo yum groupinstall -y "Development Tools"
+elif command -v pacman >/dev/null 2>&1; then
+    echo "Detected Arch system. Installing base-devel..."
+    sudo pacman -S --noconfirm base-devel
+elif command -v brew >/dev/null 2>&1; then
+    echo "Detected macOS with Homebrew. Installing Xcode command line tools..."
+    xcode-select --install 2>/dev/null || echo "Xcode tools may already be installed"
+else
+    echo "Error: Unable to detect package manager for build tools installation."
+    echo "Please install build essentials manually for your distribution."
+    exit 1
+fi
+
+# Verify installation
+if command -v cc >/dev/null 2>&1; then
+    echo "Build tools installed successfully!"
+    echo "C compiler: $(which cc)"
+else
+    echo "Error: Build tools installation failed. C compiler still not found."
+    exit 1
+fi

--- a/install.sh
+++ b/install.sh
@@ -192,6 +192,13 @@ main() {
     
     log_info "Starting dotfiles installation..."
     
+    # Check for build tools (required for Rust packages)
+    if ! command -v cc >/dev/null 2>&1; then
+        log_warning "Build tools not detected. Some tools (sheldon, eza) require compilation."
+        log_info "Run './install-build-tools.sh' first if you encounter compilation errors."
+        echo ""
+    fi
+    
     # Create XDG directories
     create_xdg_dirs
     

--- a/proto/install.sh
+++ b/proto/install.sh
@@ -8,13 +8,26 @@ echo "Setting up Proto..."
 
 # Check for build essentials (required for Rust compilation)
 if ! command -v cc >/dev/null 2>&1; then
-    echo "Warning: C compiler not found. Build tools are required for Rust packages."
-    echo "Please install build essentials first:"
-    echo "  Ubuntu/Debian: sudo apt-get install build-essential"
-    echo "  CentOS/RHEL: sudo yum groupinstall 'Development Tools'"
-    echo "  Arch: sudo pacman -S base-devel"
+    echo "Error: Build tools not found. C compiler is required for Rust package compilation."
     echo ""
-    echo "Continuing with proto installation..."
+    echo "Please install build essentials first:"
+    
+    if command -v apt-get >/dev/null 2>&1; then
+        echo "  sudo apt-get update && sudo apt-get install -y build-essential"
+    elif command -v yum >/dev/null 2>&1; then
+        echo "  sudo yum groupinstall -y 'Development Tools'"
+    elif command -v pacman >/dev/null 2>&1; then
+        echo "  sudo pacman -S base-devel"
+    else
+        echo "  Install build tools for your distribution"
+    fi
+    
+    echo ""
+    echo "Alternatively, run the build tools installer:"
+    echo "  ./install-build-tools.sh"
+    echo ""
+    echo "After installing build tools, re-run this script."
+    exit 1
 fi
 
 # Install proto if not present


### PR DESCRIPTION
## Summary
- Adds proper build tools requirement checking that fails fast with clear instructions
- Creates helper script for easy build tools installation across distributions
- Adds early warning in main installation script

## Problem Solved
Resolves the compilation error: `error: linker 'cc' not found` that occurs when trying to install Rust packages (sheldon, eza) without build tools.

## Changes
- **Enhanced**: `proto/install.sh` now checks for C compiler and exits with clear instructions if missing
- **New**: `install-build-tools.sh` helper script that installs build essentials for different distributions
- **Improved**: Main `install.sh` warns users about missing build tools before starting
- **Supports**: Multiple package managers (apt-get, yum, pacman, brew)

## Usage
Users can now:
1. Run `./install-build-tools.sh` to install build tools first, OR
2. Follow the manual instructions shown when proto installation fails

## Test plan
- [ ] Test build tools detection works correctly
- [ ] Verify clear error messages are shown when build tools missing
- [ ] Test helper script works on different distributions
- [ ] Confirm installation succeeds after build tools are installed

🤖 Generated with [Claude Code](https://claude.ai/code)