### PR TITLE
:sparkles: feat(sheldon): Prefer Homebrew over cargo compilation

### DIFF
--- a/eza/install.sh
+++ b/eza/install.sh
@@ -27,8 +27,9 @@ if ! command -v eza >/dev/null 2>&1; then
                 cargo install eza
             else
                 echo "Error: Neither Homebrew nor Rust/Cargo found"
-                echo "Please ensure either Homebrew or Rust is installed first by running:"
-                echo "  ./homebrew/install.sh  OR  ./proto/install.sh"
+                echo "Please install one of the following:"
+                echo "  Option 1 (recommended): ./homebrew/install.sh"
+                echo "  Option 2: ./install-build-tools.sh && ./proto/install.sh"
                 exit 1
             fi
         fi

--- a/sheldon/install.sh
+++ b/sheldon/install.sh
@@ -18,8 +18,11 @@ ln -sf "$SCRIPT_DIR/plugins.toml" "$HOME/.config/sheldon/plugins.toml"
 if ! command -v sheldon >/dev/null 2>&1; then
     echo "Installing Sheldon..."
     
-    # Try to install via cargo (direct command or proto)
-    if command -v cargo >/dev/null 2>&1; then
+    # Try Homebrew first (preferred - no compilation needed)
+    if command -v brew >/dev/null 2>&1; then
+        brew install sheldon
+    # Fallback to cargo/proto (requires build tools)
+    elif command -v cargo >/dev/null 2>&1; then
         cargo install sheldon
     elif command -v proto >/dev/null 2>&1 && proto run cargo -- --version >/dev/null 2>&1; then
         proto run cargo -- install sheldon
@@ -32,12 +35,15 @@ if ! command -v sheldon >/dev/null 2>&1; then
         if command -v cargo >/dev/null 2>&1; then
             cargo install sheldon
         else
-            echo "Error: Rust/Cargo not found"
-            echo "Please ensure Rust is installed first by running:"
-            echo "  ./proto/install.sh"
+            echo "Error: Neither Homebrew nor Rust/Cargo found"
+            echo "Please install one of the following:"
+            echo "  Option 1 (recommended): ./homebrew/install.sh"
+            echo "  Option 2: ./install-build-tools.sh && ./proto/install.sh"
             exit 1
         fi
     fi
+else
+    echo "Sheldon already installed"
 fi
 
 echo "Sheldon setup complete!"


### PR DESCRIPTION
## Summary
- Updates sheldon installation to prefer Homebrew over cargo compilation
- Improves error messaging to guide users to recommended installation paths
- Provides faster, more reliable installation experience

## Problem Solved
Eliminates the build tool requirement and compilation errors for sheldon installation when Homebrew is available. Users get pre-built binaries instead of having to compile from source.

## Changes
- **Enhanced**: `sheldon/install.sh` now tries Homebrew first, cargo/proto as fallback
- **Improved**: Error messages guide users to recommended installation methods
- **Consistent**: Updated `eza/install.sh` error messaging for consistency

## Installation Priority
1. **Homebrew** (preferred) - Pre-built binary, no compilation needed
2. **Cargo** (fallback) - Direct cargo install if available  
3. **Proto** (fallback) - `proto run cargo` if proto+rust available
4. **Error** - Clear guidance on next steps

## Benefits
- ✅ No build tools required when using Homebrew
- ✅ Faster installation (no compilation time)
- ✅ More reliable (no compilation failures)
- ✅ Better error messages with clear next steps

## Test Results
```bash
$ ./sheldon/install.sh
Setting up Sheldon configuration...
Installing Sheldon...
==> Downloading https://ghcr.io/v2/homebrew/core/sheldon/manifests/0.8.2
==> Pouring sheldon--0.8.2.x86_64_linux.bottle.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/sheldon/0.8.2: 11 files, 4.5MB
Sheldon setup complete\!

$ sheldon --version
sheldon 0.8.2
```

🤖 Generated with [Claude Code](https://claude.ai/code)