### PR TITLE
:bug: fix(proto): Resolve proto command not found after installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -111,6 +111,11 @@ install_all_tools() {
         
         # After installing proto, ensure it and rust are available for subsequent tools
         if [ "$tool" = "proto" ]; then
+            # Add proto to PATH if it was just installed
+            if [ -d "$HOME/.local/share/proto/bin" ]; then
+                export PATH="$HOME/.local/share/proto/bin:$PATH"
+            fi
+            
             if command -v proto >/dev/null 2>&1; then
                 log_info "Proto toolchain manager is now available for subsequent installations"
                 if proto run cargo -- --version >/dev/null 2>&1; then

--- a/proto/install.sh
+++ b/proto/install.sh
@@ -35,10 +35,18 @@ if ! command -v proto >/dev/null 2>&1; then
     echo "Installing Proto..."
     curl -fsSL https://moonrepo.dev/install/proto.sh | bash -s -- --yes
     
-    # Source proto environment
-    if [ -f "$HOME/.proto/env" ]; then
-        source "$HOME/.proto/env"
+    # Proto is installed to a specific location
+    PROTO_BIN="$HOME/.local/share/proto/bin/proto"
+    
+    # Check if proto was installed successfully
+    if [ ! -f "$PROTO_BIN" ]; then
+        echo "Error: Proto installation failed. Expected binary not found at $PROTO_BIN"
+        exit 1
     fi
+    
+    # Add proto to PATH for this session
+    export PATH="$HOME/.local/share/proto/bin:$PATH"
+    echo "Proto installed successfully"
 else
     echo "Proto already installed"
 fi


### PR DESCRIPTION
## Summary
- Fixes proto installation error where the command is not found after successful installation
- Adds proto binary path to PATH immediately after installation
- Ensures seamless installation flow without requiring terminal restart

## Problem Solved
Resolves the error:
```
Installing Proto...
Successfully installed proto to /home/nemo/.local/share/proto/bin/proto
...
Error: proto command not found after installation
```

## Changes
- **Fixed**: `proto/install.sh` now exports proto binary path to PATH
- **Added**: Verification check for proto binary at expected location
- **Updated**: Main `install.sh` to handle proto PATH for subsequent tools
- **Improved**: Error handling with clear failure messages

## Technical Details
Proto installs to `~/.local/share/proto/bin/proto` instead of the previously expected `~/.proto/env`. The script now:
1. Checks if proto binary exists at the expected location after installation
2. Adds the binary directory to PATH for the current session
3. Allows proto commands to work immediately without terminal restart

## Test Results
```bash
$ ./proto/install.sh
Setting up Proto...
Installing Proto...
Proto installed successfully
Installing Rust via Proto...
[rust] Installing Rust 1.87.0
Rust installed via proto
Proto setup complete\!
```

🤖 Generated with [Claude Code](https://claude.ai/code)