### PR TITLE
:bug: fix(zsh): add .zshrc file to prevent zsh-newuser-install prompt

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -42,6 +42,10 @@ jobs:
           echo "❌ Zsh config not found"
           exit 1
         fi
+        if [ ! -f ~/.config/zsh/.zshrc ]; then
+          echo "❌ Zsh .zshrc not linked"
+          exit 1
+        fi
         if [ ! -f ~/.config/zsh/env.zsh ]; then
           echo "❌ Zsh env.zsh not linked"
           exit 1

--- a/test-install.sh
+++ b/test-install.sh
@@ -126,6 +126,7 @@ test_individual_tools() {
     run_test "Zsh configuration" "
         ./install.sh zsh >/dev/null 2>&1 && 
         [ -f ~/.zshenv ] && 
+        [ -f ~/.config/zsh/.zshrc ] &&
         [ -f ~/.config/zsh/env.zsh ]
     "
 }

--- a/zsh/install.sh
+++ b/zsh/install.sh
@@ -18,6 +18,7 @@ rm -rf "$HOME/.config/zsh/zsh" "$HOME/.config/zsh/.zshenv"
 
 # Link zsh configuration files individually
 ln -sf "$SCRIPT_DIR/.zshenv" "$HOME/.zshenv"
+ln -sf "$SCRIPT_DIR/.zshrc" "$HOME/.config/zsh/.zshrc"
 ln -sf "$SCRIPT_DIR/abbreviations.zsh" "$HOME/.config/zsh/abbreviations.zsh"
 ln -sf "$SCRIPT_DIR/env.zsh" "$HOME/.config/zsh/env.zsh"
 ln -sf "$SCRIPT_DIR/functions.zsh" "$HOME/.config/zsh/functions.zsh"


### PR DESCRIPTION
## Summary
- Add missing .zshrc file to prevent zsh-newuser-install prompt after running install.sh
- Update zsh install script to symlink .zshrc properly
- Update CI and test suite to verify .zshrc is created

## Problem
After running `install.sh` and executing `exec $SHELL -l`, users were seeing the zsh-newuser-install prompt because zsh couldn't find startup files in ~/.config/zsh/.

## Solution
- Created comprehensive .zshrc with proper zsh configuration
- Added .zshrc symlinking to zsh install script
- Updated tests to verify .zshrc exists

## Test plan
- [x] Local tests pass (21/21)
- [x] No more zsh-newuser-install prompt after installation
- [x] Zsh starts normally with proper configuration

🤖 Generated with [Claude Code](https://claude.ai/code)