### PR TITLE
:bug: fix(zsh): add .zshrc file to prevent zsh-newuser-install prompt and fix sheldon plugin errors

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -42,6 +42,10 @@ jobs:
           echo "❌ Zsh config not found"
           exit 1
         fi
+        if [ ! -f ~/.config/zsh/.zshrc ]; then
+          echo "❌ Zsh .zshrc not linked"
+          exit 1
+        fi
         if [ ! -f ~/.config/zsh/env.zsh ]; then
           echo "❌ Zsh env.zsh not linked"
           exit 1

--- a/sheldon/plugins.toml
+++ b/sheldon/plugins.toml
@@ -1,5 +1,11 @@
 # Sheldon plugin configuration
 
+# Global settings
+shell = "zsh"
+
+# Default apply setting for plugins without explicit apply
+apply = ["source"]
+
 # Shell completions
 [plugins.zsh-completions]
 github = "zsh-users/zsh-completions"

--- a/test-install.sh
+++ b/test-install.sh
@@ -126,6 +126,7 @@ test_individual_tools() {
     run_test "Zsh configuration" "
         ./install.sh zsh >/dev/null 2>&1 && 
         [ -f ~/.zshenv ] && 
+        [ -f ~/.config/zsh/.zshrc ] &&
         [ -f ~/.config/zsh/env.zsh ]
     "
 }

--- a/zsh/install.sh
+++ b/zsh/install.sh
@@ -18,6 +18,7 @@ rm -rf "$HOME/.config/zsh/zsh" "$HOME/.config/zsh/.zshenv"
 
 # Link zsh configuration files individually
 ln -sf "$SCRIPT_DIR/.zshenv" "$HOME/.zshenv"
+ln -sf "$SCRIPT_DIR/.zshrc" "$HOME/.config/zsh/.zshrc"
 ln -sf "$SCRIPT_DIR/abbreviations.zsh" "$HOME/.config/zsh/abbreviations.zsh"
 ln -sf "$SCRIPT_DIR/env.zsh" "$HOME/.config/zsh/env.zsh"
 ln -sf "$SCRIPT_DIR/functions.zsh" "$HOME/.config/zsh/functions.zsh"


### PR DESCRIPTION
## Summary
- Add missing .zshrc file to prevent zsh-newuser-install prompt after running install.sh
- Fix sheldon configuration to resolve plugin loading errors
- Update zsh install script to symlink .zshrc properly
- Update CI and test suite to verify .zshrc is created

## Problems Fixed

### 1. Zsh Newuser Install Prompt
After running `install.sh` and executing `exec $SHELL -l`, users were seeing the zsh-newuser-install prompt because zsh couldn't find startup files in ~/.config/zsh/.

### 2. Sheldon Plugin Errors
After `exec zsh`, users were seeing multiple errors:
```
error: failed to install plugin `zsh-completions`
  due to: no global `apply` defined (help: set `shell` to use defaults)
```

## Solutions Applied

### 1. Added .zshrc Configuration
- Created comprehensive .zshrc with proper zsh configuration
- Added .zshrc symlinking to zsh install script
- Includes vi mode, history settings, completions, and tool integrations

### 2. Fixed Sheldon Configuration
- Added global `shell = "zsh"` setting
- Added default `apply = ["source"]` configuration
- Now all plugins load without errors

## Test plan
- [x] Local tests pass (21/21)
- [x] No more zsh-newuser-install prompt after installation
- [x] No more sheldon plugin errors after `exec zsh`
- [x] Zsh starts normally with proper configuration
- [x] All shell enhancements work (completions, syntax highlighting, etc.)

🤖 Generated with [Claude Code](https://claude.ai/code)