### PR TITLE
:bug: fix(zsh): replace zsh-abbr with regular aliases to prevent syntax errors

### DIFF
--- a/sheldon/plugins.toml
+++ b/sheldon/plugins.toml
@@ -25,10 +25,6 @@ use = ["{{ name }}.zsh"]
 github = "zsh-users/zsh-history-substring-search"
 use = ["{{ name }}.zsh"]
 
-# Abbreviations support (like fish shell)
-[plugins.zsh-abbr]
-github = "olets/zsh-abbr"
-use = ["{{ name }}.zsh"]
 
 # FZF tab completion
 [plugins.fzf-tab]

--- a/zsh/abbreviations.zsh
+++ b/zsh/abbreviations.zsh
@@ -1,144 +1,142 @@
-# Abbreviations using zsh-abbr
-# These expand when you press space or enter
+# Shell aliases and shortcuts
+# Using aliases instead of zsh-abbr for better compatibility
 
-# Navigation
-abbr ".." "cd .."
-abbr "..." "cd ../.."
-abbr "...." "cd ../../.."
-abbr "....." "cd ../../../.."
+# Navigation shortcuts
+alias ..='cd ..'
+alias ...='cd ../..'
+alias ....='cd ../../..'
+alias .....='cd ../../../..'
 
-# Listing (using eza)
-abbr "ls" "eza"
-abbr "l" "eza -l"
-abbr "la" "eza -la"
-abbr "ll" "eza -lag"
-abbr "lt" "eza --tree"
-abbr "tree" "eza --tree"
+# Enhanced listing with eza
+alias ls='eza'
+alias l='eza -l'
+alias la='eza -la'
+alias ll='eza -lag'
+alias lt='eza --tree'
+alias tree='eza --tree'
 
-# Git abbreviations
-abbr "g" "git"
-abbr "ga" "git add"
-abbr "gaa" "git add --all"
-abbr "gap" "git add --patch"
-abbr "gc" "git commit"
-abbr "gcm" "git commit -m"
-abbr "gca" "git commit --amend"
-abbr "gcan" "git commit --amend --no-edit"
-abbr "gco" "git checkout"
-abbr "gcob" "git checkout -b"
-abbr "gd" "git diff"
-abbr "gdc" "git diff --cached"
-abbr "gds" "git diff --staged"
-abbr "gf" "git fetch"
-abbr "gl" "git log"
-abbr "glg" "git log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit"
-abbr "gll" "git log --pretty=format:'%C(yellow)%h%Cred%d %Creset%s%Cblue [%cn]' --decorate --numstat"
-abbr "gpl" "git pull"
-abbr "gps" "git push"
-abbr "gpsu" "git push -u origin HEAD"
-abbr "gs" "git status"
-abbr "gst" "git status"
-abbr "gss" "git stash save"
-abbr "gsl" "git stash list"
-abbr "gsp" "git stash pop"
-abbr "gsa" "git stash apply"
-abbr "gbr" "git branch"
-abbr "grs" "git reset"
-abbr "grsh" "git reset --hard"
-abbr "grss" "git reset --soft"
+# Git shortcuts
+alias g='git'
+alias ga='git add'
+alias gaa='git add --all'
+alias gap='git add --patch'
+alias gc='git commit'
+alias gcm='git commit -m'
+alias gca='git commit --amend'
+alias gcan='git commit --amend --no-edit'
+alias gco='git checkout'
+alias gcob='git checkout -b'
+alias gd='git diff'
+alias gdc='git diff --cached'
+alias gds='git diff --staged'
+alias gf='git fetch'
+alias gl='git log'
+alias glg="git log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit"
+alias gll="git log --pretty=format:'%C(yellow)%h%Cred%d %Creset%s%Cblue [%cn]' --decorate --numstat"
+alias gpl='git pull'
+alias gps='git push'
+alias gpsu='git push -u origin HEAD'
+alias gs='git status'
+alias gst='git status'
+alias gss='git stash save'
+alias gsl='git stash list'
+alias gsp='git stash pop'
+alias gsa='git stash apply'
+alias gbr='git branch'
+alias grs='git reset'
+alias grsh='git reset --hard'
+alias grss='git reset --soft'
 
-# Lazygit abbreviations
-abbr "lg" "lazygit"
-abbr "lgs" "lazygit status"
-abbr "lgb" "lazygit log"
+# Lazygit shortcuts
+alias lg='lazygit'
+alias lgs='lazygit status'
+alias lgb='lazygit log'
 
-# Docker abbreviations
-abbr "d" "docker"
-abbr "dc" "docker compose"
-abbr "dps" "docker ps"
-abbr "dpsa" "docker ps -a"
-abbr "di" "docker images"
-abbr "dr" "docker run"
-abbr "drit" "docker run -it"
-abbr "drm" "docker rm"
-abbr "drmi" "docker rmi"
-abbr "dl" "docker logs"
-abbr "de" "docker exec"
-abbr "deit" "docker exec -it"
+# Docker shortcuts
+alias d='docker'
+alias dc='docker compose'
+alias dps='docker ps'
+alias dpsa='docker ps -a'
+alias di='docker images'
+alias dr='docker run'
+alias drit='docker run -it'
+alias drm='docker rm'
+alias drmi='docker rmi'
+alias dl='docker logs'
+alias de='docker exec'
+alias deit='docker exec -it'
 
-# Editor abbreviations
-abbr "v" "nvim"
-abbr "vi" "nvim"
-abbr "vim" "nvim"
+# Editor shortcuts
+alias v='nvim'
+alias vi='nvim'
+alias vim='nvim'
 
-# System abbreviations
-abbr "reload" "exec \$SHELL"
-abbr "path" "echo -e \${PATH//:/\\\\n}"
-abbr "h" "history"
-abbr "j" "jobs -l"
-abbr "c" "clear"
+# System shortcuts
+alias reload='exec $SHELL'
+alias path='echo -e ${PATH//:/\\n}'
+alias h='history'
+alias j='jobs -l'
+alias c='clear'
 
-# Safety nets with confirmation
-abbr "rm" "rm -i"
-abbr "cp" "cp -i"
-abbr "mv" "mv -i"
+# Safety nets
+alias rm='rm -i'
+alias cp='cp -i'
+alias mv='mv -i'
 
-# Create parent directories on demand
-abbr "mkdir" "mkdir -pv"
-
-# Human-readable sizes
-abbr "df" "df -h"
-abbr "du" "du -h"
+# Enhanced commands
+alias mkdir='mkdir -pv'
+alias df='df -h'
+alias du='du -h'
 
 # Process management
-abbr "psg" "ps aux | grep -v grep | grep -i -e VSZ -e"
-abbr "psmem" "ps auxf | sort -nr -k 4 | head -10"
-abbr "pscpu" "ps auxf | sort -nr -k 3 | head -10"
+alias psg='ps aux | grep -v grep | grep -i -e VSZ -e'
+alias psmem='ps auxf | sort -nr -k 4 | head -10'
+alias pscpu='ps auxf | sort -nr -k 3 | head -10'
 
 # Network
-abbr "ports" "netstat -tulanp"
+alias ports='netstat -tulanp'
 
-# Kubernetes
-abbr "k" "kubectl"
-abbr "kg" "kubectl get"
-abbr "kd" "kubectl describe"
-abbr "ka" "kubectl apply"
-abbr "kdel" "kubectl delete"
-abbr "kl" "kubectl logs"
-abbr "ke" "kubectl exec"
-abbr "kp" "kubectl port-forward"
+# Kubernetes shortcuts
+alias k='kubectl'
+alias kg='kubectl get'
+alias kd='kubectl describe'
+alias ka='kubectl apply'
+alias kdel='kubectl delete'
+alias kl='kubectl logs'
+alias ke='kubectl exec'
+alias kp='kubectl port-forward'
 
-# Terraform
-abbr "tf" "terraform"
-abbr "tfi" "terraform init"
-abbr "tfp" "terraform plan"
-abbr "tfa" "terraform apply"
-abbr "tfd" "terraform destroy"
-abbr "tfv" "terraform validate"
-abbr "tff" "terraform fmt"
+# Terraform shortcuts
+alias tf='terraform'
+alias tfi='terraform init'
+alias tfp='terraform plan'
+alias tfa='terraform apply'
+alias tfd='terraform destroy'
+alias tfv='terraform validate'
+alias tff='terraform fmt'
 
-# Tmux
-abbr "tm" "tmux"
-abbr "tma" "tmux attach"
-abbr "tmn" "tmux new-session"
-abbr "tml" "tmux list-sessions"
+# Tmux shortcuts
+alias tm='tmux'
+alias tma='tmux attach'
+alias tmn='tmux new-session'
+alias tml='tmux list-sessions'
 
-# Cargo (Rust)
-abbr "cb" "cargo build"
-abbr "cr" "cargo run"
-abbr "ct" "cargo test"
-abbr "cc" "cargo check"
-abbr "cf" "cargo fmt"
-abbr "ccl" "cargo clippy"
+# Cargo (Rust) shortcuts
+alias cb='cargo build'
+alias cr='cargo run'
+alias ct='cargo test'
+alias cc='cargo check'
+alias cf='cargo fmt'
+alias ccl='cargo clippy'
 
-# npm/yarn
-abbr "ni" "npm install"
-abbr "nr" "npm run"
-abbr "ns" "npm start"
-abbr "nt" "npm test"
-abbr "nb" "npm run build"
-abbr "yi" "yarn install"
-abbr "yr" "yarn run"
-abbr "ys" "yarn start"
-abbr "yt" "yarn test"
-abbr "yb" "yarn build"
+# npm/yarn shortcuts
+alias ni='npm install'
+alias nr='npm run'
+alias ns='npm start'
+alias nt='npm test'
+alias nb='npm run build'
+alias yi='yarn install'
+alias yr='yarn run'
+alias ys='yarn start'
+alias yt='yarn test'
+alias yb='yarn build'


### PR DESCRIPTION
## Summary
- Replace zsh-abbr plugin with regular zsh aliases to fix syntax errors
- Remove zsh-abbr from sheldon configuration
- Convert all abbreviations to standard alias format

## Problem
After `exec zsh`, users were seeing multiple zsh-abbr syntax errors:
```
abbr add: Expected one argument, got 2: .. cd ..
abbr add: Expected one argument, got 2: ... cd ../..
```

## Solution
- Converted all zsh-abbr commands to standard `alias` format
- Removed problematic zsh-abbr plugin from sheldon
- Kept all the same shortcuts but using more reliable alias syntax

## Benefits
- ✅ No more syntax errors on shell startup
- ✅ All shortcuts still work (ga, gc, ll, etc.)
- ✅ Better compatibility across different zsh versions
- ✅ Faster shell startup (no abbr expansion processing)

## Test plan
- [x] No errors after `exec zsh`
- [x] All aliases properly defined
- [x] Git shortcuts work (ga, gc, gd, etc.)
- [x] Directory shortcuts work (.., ..., etc.)
- [x] Tool shortcuts work (v for nvim, lg for lazygit, etc.)

🤖 Generated with [Claude Code](https://claude.ai/code)