### PR TITLE
:bug: fix(zsh): add homebrew and proto PATH exports to persist tools after terminal restart

### DIFF
--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -12,6 +12,16 @@ export ZDOTDIR="$XDG_CONFIG_HOME/zsh"
 # Path additions
 export PATH="$HOME/.local/bin:$PATH"
 
+# Homebrew on Linux
+if [ -d "/home/linuxbrew/.linuxbrew" ]; then
+    eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+fi
+
+# Proto toolchain manager
+if [ -d "$HOME/.local/share/proto/bin" ]; then
+    export PATH="$HOME/.local/share/proto/bin:$PATH"
+fi
+
 # Source the rest of zsh configuration from XDG config
 if [ -f "$ZDOTDIR/.zshenv" ]; then
     source "$ZDOTDIR/.zshenv"


### PR DESCRIPTION
## Summary
- Add homebrew and proto PATH exports to .zshenv to ensure tools remain available after terminal restart
- Fixes issue where sheldon, zoxide, starship commands were not found after relaunching terminal

## Test plan
- [ ] Install dotfiles and verify tools work initially
- [ ] Restart terminal and verify all tools are still available in PATH
- [ ] Verify no PATH-related errors in zsh startup

🤖 Generated with [Claude Code](https://claude.ai/code)