### PR TITLE
:bug: fix(zsh): prevent duplicate abbreviation loading on every shell start

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -124,7 +124,11 @@ eval "$(starship init zsh)"
     done
     
     if command -v abbr >/dev/null 2>&1; then
-        [[ -f "$ZDOTDIR/abbreviations.zsh" ]] && source "$ZDOTDIR/abbreviations.zsh"
+        # Only load abbreviations if they haven't been loaded yet
+        # Check if a common abbreviation exists
+        if ! abbr list | grep -q "^g="; then
+            [[ -f "$ZDOTDIR/abbreviations.zsh" ]] && source "$ZDOTDIR/abbreviations.zsh"
+        fi
     else
         # Fallback to aliases if abbr is not available
         echo "Warning: zsh-abbr not loaded, using aliases instead"


### PR DESCRIPTION
## Summary
- Add check to prevent loading abbreviations if they're already loaded
- Fixes issue where abbreviations were being added repeatedly on every shell start
- Now abbreviations are only loaded once during the first zsh execution

## Test plan
- [ ] Start zsh and verify abbreviations work
- [ ] Start multiple new shells and verify no duplicate loading messages
- [ ] Test that abbreviations persist correctly across sessions

🤖 Generated with [Claude Code](https://claude.ai/code)