### PR TITLE
:sparkles: feat(zsh): auto-copy user-abbreviations to zsh-abbr config

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -113,13 +113,6 @@ eval "$(starship init zsh)"
 # Source functions
 [[ -f "$ZDOTDIR/functions.zsh" ]] && source "$ZDOTDIR/functions.zsh"
 
-# Initialize zsh-abbr with copied user abbreviations
-if command -v abbr >/dev/null 2>&1; then
-    # Load user abbreviations from the copied file
-    [[ -f "$ZDOTDIR/user-abbreviations" ]] && source "$ZDOTDIR/user-abbreviations"
-else
-    echo "Warning: zsh-abbr not available"
-fi
 # proto
 export PROTO_HOME="$XDG_DATA_HOME/proto";
 export PATH="$PROTO_HOME/shims:$PROTO_HOME/bin:$PATH";

--- a/zsh/install.sh
+++ b/zsh/install.sh
@@ -19,9 +19,15 @@ rm -rf "$HOME/.config/zsh/zsh" "$HOME/.config/zsh/.zshenv"
 # Link zsh configuration files individually
 ln -sf "$SCRIPT_DIR/.zshenv" "$HOME/.zshenv"
 ln -sf "$SCRIPT_DIR/.zshrc" "$HOME/.config/zsh/.zshrc"
-ln -sf "$SCRIPT_DIR/user-abbreviations" "$HOME/.config/zsh/user-abbreviations"
 ln -sf "$SCRIPT_DIR/env.zsh" "$HOME/.config/zsh/env.zsh"
 ln -sf "$SCRIPT_DIR/functions.zsh" "$HOME/.config/zsh/functions.zsh"
+
+# Copy user-abbreviations to zsh-abbr config directory
+if command -v abbr >/dev/null 2>&1 || [[ -d "$HOME/.config/zsh-abbr" ]]; then
+    mkdir -p "$HOME/.config/zsh-abbr"
+    cp "$SCRIPT_DIR/user-abbreviations" "$HOME/.config/zsh-abbr/user-abbreviations"
+    echo "Copied user-abbreviations to zsh-abbr config directory"
+fi
 
 # Install zsh if not present
 if ! command -v zsh >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Remove manual abbreviation loading from .zshrc since zsh-abbr handles this automatically
- Add logic in install.sh to copy user-abbreviations to ~/.config/zsh-abbr/ during setup
- Keep user-abbreviations file in dotfiles for version control and easy updates

## Test plan
- [ ] Verify install.sh creates ~/.config/zsh-abbr directory if needed
- [ ] Confirm user-abbreviations is copied to ~/.config/zsh-abbr/
- [ ] Test that zsh-abbr automatically loads abbreviations without manual sourcing
- [ ] Check that abbreviations work correctly after fresh install

🤖 Generated with [Claude Code](https://claude.ai/code)