### PR TITLE
:bug: fix(zsh): prevent zsh-abbr loading errors on shell startup

### DIFF
--- a/sheldon/plugins.toml
+++ b/sheldon/plugins.toml
@@ -28,7 +28,7 @@ use = ["{{ name }}.zsh"]
 # Abbreviations support (like fish shell)
 [plugins.zsh-abbr]
 github = "olets/zsh-abbr"
-use = ["*.plugin.zsh", "*.zsh"]
+use = ["zsh-abbr.plugin.zsh"]
 
 # FZF tab completion
 [plugins.fzf-tab]

--- a/zsh/abbr-init.zsh
+++ b/zsh/abbr-init.zsh
@@ -3,20 +3,26 @@
 
 # Only proceed if zsh-abbr is loaded
 if (( ! ${+functions[abbr]} )); then
-    echo "Warning: zsh-abbr is not loaded. Skipping abbreviations setup." >&2
     return 0
 fi
 
 # Set the abbreviations file path
 local abbr_config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/zsh-abbr"
 local user_abbr_file="${abbr_config_dir}/user-abbreviations"
+local source_abbr_file="${XDG_CONFIG_HOME:-$HOME/.config}/zsh/user-abbreviations"
+
+# Create zsh-abbr config directory if it doesn't exist
+[[ ! -d "$abbr_config_dir" ]] && mkdir -p "$abbr_config_dir"
+
+# Copy user abbreviations to zsh-abbr config directory if source exists
+if [[ -f "$source_abbr_file" && "$source_abbr_file" -nt "$user_abbr_file" ]]; then
+    cp "$source_abbr_file" "$user_abbr_file"
+fi
 
 # Check if user abbreviations file exists
 if [[ ! -f "$user_abbr_file" ]]; then
-    echo "Info: No user abbreviations file found at $user_abbr_file" >&2
     return 0
 fi
 
 # Source the user abbreviations file
-# The file should contain abbr commands without the need for additional processing
 source "$user_abbr_file"

--- a/zsh/user-abbreviations
+++ b/zsh/user-abbreviations
@@ -1,4 +1,10 @@
+#!/usr/bin/env zsh
 # zsh-abbr user abbreviations
+
+# Exit if abbr function is not available
+if ! command -v abbr &> /dev/null; then
+    return 0 2>/dev/null || exit 0
+fi
 abbr ".."="cd .."
 abbr "..."="cd ../.."
 abbr "...."="cd ../../.."


### PR DESCRIPTION
## Summary
- Prevent "command not found: abbr" errors during shell initialization
- Fix sheldon loading unnecessary zsh-abbr test files
- Improve abbreviation loading resilience

## Changes
- Added guard in `user-abbreviations` to check if abbr command exists before executing
- Updated sheldon config to only load `zsh-abbr.plugin.zsh` (excluding test files that were causing errors)
- Removed verbose warnings from `abbr-init.zsh` for cleaner startup
- Enhanced abbreviation file management with automatic copying to zsh-abbr config directory

## Test plan
- [ ] Start new zsh session with `exec $SHELL`
- [ ] Verify no "command not found: abbr" errors appear
- [ ] Verify no test file loading errors
- [ ] Confirm abbreviations work correctly after shell loads

🤖 Generated with [Claude Code](https://claude.ai/code)