### PR TITLE
:sparkles: feat(zsh): add bun global packages bin directory to PATH

### DIFF
--- a/zsh/env.zsh
+++ b/zsh/env.zsh
@@ -45,5 +45,6 @@ path=(
     "$CARGO_HOME/bin"
     "$PROTO_HOME/shims"
     "$PROTO_HOME/bin"
+    "$HOME/.cache/.bun/bin"
     $path
 )


### PR DESCRIPTION
## Summary
- Add `$HOME/.cache/.bun/bin` to PATH in zsh environment configuration
- Enables access to globally installed bun packages via `bun install -g`

## Test plan
- [x] Verify bun global bin directory path is correct (`bun pm bin -g`)
- [x] Confirm directory exists and contains global packages
- [ ] Test that globally installed packages are accessible after sourcing updated env.zsh

🤖 Generated with [Claude Code](https://claude.ai/code)