### PR TITLE
:bug: fix(zsh): ensure abbreviations load properly after install.sh execution

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -110,8 +110,14 @@ eval "$(starship init zsh)"
 # Load local configuration if exists
 [[ -f "$ZDOTDIR/.zshrc.local" ]] && source "$ZDOTDIR/.zshrc.local"
 
+# Source environment variables
+[[ -f "$ZDOTDIR/env.zsh" ]] && source "$ZDOTDIR/env.zsh"
+
 # Source functions
 [[ -f "$ZDOTDIR/functions.zsh" ]] && source "$ZDOTDIR/functions.zsh"
+
+# Initialize abbreviations (after sheldon loads plugins)
+[[ -f "$ZDOTDIR/abbr-init.zsh" ]] && source "$ZDOTDIR/abbr-init.zsh"
 
 # proto
 export PROTO_HOME="$XDG_DATA_HOME/proto";

--- a/zsh/install.sh
+++ b/zsh/install.sh
@@ -21,13 +21,13 @@ ln -sf "$SCRIPT_DIR/.zshenv" "$HOME/.zshenv"
 ln -sf "$SCRIPT_DIR/.zshrc" "$HOME/.config/zsh/.zshrc"
 ln -sf "$SCRIPT_DIR/env.zsh" "$HOME/.config/zsh/env.zsh"
 ln -sf "$SCRIPT_DIR/functions.zsh" "$HOME/.config/zsh/functions.zsh"
+ln -sf "$SCRIPT_DIR/abbr-init.zsh" "$HOME/.config/zsh/abbr-init.zsh"
 
 # Copy user-abbreviations to zsh-abbr config directory
-if command -v abbr >/dev/null 2>&1 || [[ -d "$HOME/.config/zsh-abbr" ]]; then
-    mkdir -p "$HOME/.config/zsh-abbr"
-    cp "$SCRIPT_DIR/user-abbreviations" "$HOME/.config/zsh-abbr/user-abbreviations"
-    echo "Copied user-abbreviations to zsh-abbr config directory"
-fi
+# Always copy the file, regardless of whether abbr is installed yet
+mkdir -p "$HOME/.config/zsh-abbr"
+cp "$SCRIPT_DIR/user-abbreviations" "$HOME/.config/zsh-abbr/user-abbreviations"
+echo "Copied user-abbreviations to zsh-abbr config directory"
 
 # Install zsh if not present
 if ! command -v zsh >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Fix abbreviations from user-abbreviations not loading after running install.sh
- Resolve timing issues with zsh-abbr plugin initialization and configuration setup

## Changes Made
- Add sourcing of env.zsh and abbr-init.zsh to .zshrc after sheldon plugin loading
- Link abbr-init.zsh file during installation process in zsh/install.sh
- Remove conditional check for abbr command when copying user-abbreviations
- Always copy user-abbreviations file regardless of abbr command availability

## Root Cause
The issue occurred because:
1. .zshrc wasn't sourcing abbr-init.zsh which handles abbreviation loading
2. install.sh only copied user-abbreviations if abbr command was available (timing issue)
3. abbr-init.zsh wasn't being linked to the config directory

## Test Plan
- [x] Run install.sh and verify abbreviations are copied to ~/.config/zsh-abbr/
- [x] Start new zsh session and confirm abbreviations are loaded
- [x] Verify no "already has expansion" errors indicate successful loading

🤖 Generated with [Claude Code](https://claude.ai/code)