### PR TITLE
:bug: fix(zsh): ensure history persistence across terminal sessions

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -1,5 +1,8 @@
 # Zsh configuration file
 
+# Source environment variables first (needed for HISTFILE)
+[[ -f "$ZDOTDIR/env.zsh" ]] && source "$ZDOTDIR/env.zsh"
+
 # Create necessary directories
 mkdir -p "$XDG_STATE_HOME/zsh"
 mkdir -p "$XDG_CACHE_HOME/zsh"
@@ -27,6 +30,13 @@ setopt HIST_SAVE_NO_DUPS         # Do not write a duplicate event to the history
 setopt HIST_VERIFY               # Do not execute immediately upon history expansion
 setopt INC_APPEND_HISTORY        # Write to the history file immediately, not when the shell exits
 setopt SHARE_HISTORY             # Share history between all sessions
+setopt HIST_FCNTL_LOCK          # Use system's fcntl call for file locking
+
+# Additional history safety measures
+[[ -f "$HISTFILE" ]] || touch "$HISTFILE"
+
+# Ensure history is written on shell exit
+trap 'fc -W' EXIT
 
 # Directory options
 setopt AUTO_CD                   # Auto cd to directory when typing directory name
@@ -109,9 +119,6 @@ eval "$(starship init zsh)"
 
 # Load local configuration if exists
 [[ -f "$ZDOTDIR/.zshrc.local" ]] && source "$ZDOTDIR/.zshrc.local"
-
-# Source environment variables
-[[ -f "$ZDOTDIR/env.zsh" ]] && source "$ZDOTDIR/env.zsh"
 
 # Source functions
 [[ -f "$ZDOTDIR/functions.zsh" ]] && source "$ZDOTDIR/functions.zsh"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -110,8 +110,14 @@ eval "$(starship init zsh)"
 # Load local configuration if exists
 [[ -f "$ZDOTDIR/.zshrc.local" ]] && source "$ZDOTDIR/.zshrc.local"
 
+# Source environment variables
+[[ -f "$ZDOTDIR/env.zsh" ]] && source "$ZDOTDIR/env.zsh"
+
 # Source functions
 [[ -f "$ZDOTDIR/functions.zsh" ]] && source "$ZDOTDIR/functions.zsh"
+
+# Initialize abbreviations (after sheldon loads plugins)
+[[ -f "$ZDOTDIR/abbr-init.zsh" ]] && source "$ZDOTDIR/abbr-init.zsh"
 
 # proto
 export PROTO_HOME="$XDG_DATA_HOME/proto";

--- a/zsh/env.zsh
+++ b/zsh/env.zsh
@@ -19,8 +19,15 @@ export RUSTUP_HOME="$XDG_DATA_HOME/rustup"
 
 # Zsh history settings
 export HISTFILE="$XDG_STATE_HOME/zsh/history"
-export HISTSIZE=50000
-export SAVEHIST=50000
+export HISTSIZE=100000
+export SAVEHIST=100000
+
+# Ensure history file exists and has proper permissions
+if [[ ! -f "$HISTFILE" ]]; then
+    mkdir -p "$(dirname "$HISTFILE")"
+    touch "$HISTFILE"
+    chmod 600 "$HISTFILE"
+fi
 
 # Default applications
 export EDITOR="nvim"

--- a/zsh/install.sh
+++ b/zsh/install.sh
@@ -21,13 +21,13 @@ ln -sf "$SCRIPT_DIR/.zshenv" "$HOME/.zshenv"
 ln -sf "$SCRIPT_DIR/.zshrc" "$HOME/.config/zsh/.zshrc"
 ln -sf "$SCRIPT_DIR/env.zsh" "$HOME/.config/zsh/env.zsh"
 ln -sf "$SCRIPT_DIR/functions.zsh" "$HOME/.config/zsh/functions.zsh"
+ln -sf "$SCRIPT_DIR/abbr-init.zsh" "$HOME/.config/zsh/abbr-init.zsh"
 
 # Copy user-abbreviations to zsh-abbr config directory
-if command -v abbr >/dev/null 2>&1 || [[ -d "$HOME/.config/zsh-abbr" ]]; then
-    mkdir -p "$HOME/.config/zsh-abbr"
-    cp "$SCRIPT_DIR/user-abbreviations" "$HOME/.config/zsh-abbr/user-abbreviations"
-    echo "Copied user-abbreviations to zsh-abbr config directory"
-fi
+# Always copy the file, regardless of whether abbr is installed yet
+mkdir -p "$HOME/.config/zsh-abbr"
+cp "$SCRIPT_DIR/user-abbreviations" "$HOME/.config/zsh-abbr/user-abbreviations"
+echo "Copied user-abbreviations to zsh-abbr config directory"
 
 # Install zsh if not present
 if ! command -v zsh >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Fixed zsh history reset issue by correcting configuration sourcing order
- Enhanced history capacity and added safety measures for better persistence

## Changes
- Move env.zsh sourcing to top of .zshrc before history options are set
- Increase HISTSIZE and SAVEHIST to 100,000 entries for larger history capacity
- Add HIST_FCNTL_LOCK option for improved file locking mechanisms
- Add safety measures including history file creation and proper permissions (600)
- Add exit trap to ensure history is written when shell exits

## Test plan
- [ ] Restart zsh shell and verify history file location is correct
- [ ] Execute commands and verify they persist after closing terminal
- [ ] Open multiple terminal sessions and verify history sharing works
- [ ] Check that history file has proper permissions (600)

🤖 Generated with [Claude Code](https://claude.ai/code)