### PR TITLE
:bug: fix(nvim): add missing lua directory symlink in install script

### DIFF
--- a/nvim/install.sh
+++ b/nvim/install.sh
@@ -13,6 +13,7 @@ mkdir -p "$HOME/.config/nvim"
 
 # Link nvim configuration
 ln -sf "$SCRIPT_DIR/init.lua" "$HOME/.config/nvim/init.lua"
+ln -sf "$SCRIPT_DIR/lua" "$HOME/.config/nvim/lua"
 
 # Install neovim if not present
 if ! command -v nvim >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Fixes Neovim configuration loading error where modules couldn't be found on first startup
- Adds missing symlink creation for lua directory in nvim/install.sh script

## Test plan
- [ ] Run nvim/install.sh on a fresh system
- [ ] Start Neovim and verify no "module not found" errors occur
- [ ] Verify all config modules load correctly

🤖 Generated with [Claude Code](https://claude.ai/code)