### PR TITLE
:bug: fix(zsh): prevent duplicate abbreviation loading warnings

### DIFF
--- a/zsh/abbr-init.zsh
+++ b/zsh/abbr-init.zsh
@@ -24,5 +24,6 @@ if [[ ! -f "$user_abbr_file" ]]; then
     return 0
 fi
 
-# Source the user abbreviations file
-source "$user_abbr_file"
+# Note: Don't source the user abbreviations file here
+# The zsh-abbr plugin will automatically load from ~/.config/zsh-abbr/user-abbreviations
+# Sourcing it here would cause duplicate abbreviation warnings


### PR DESCRIPTION
## Summary
- Remove redundant sourcing of user-abbreviations file in abbr-init.zsh since zsh-abbr plugin automatically loads from ~/.config/zsh-abbr/user-abbreviations
- This prevents "already has an expansion" warnings on shell startup

## Test plan
- [ ] Run install.sh and verify no duplicate abbreviation warnings appear
- [ ] Confirm abbreviations still work correctly after the fix

🤖 Generated with [Claude Code](https://claude.ai/code)