### PR TITLE
:bug: fix(zsh): correct zsh-abbr widget binding to use abbr-expand-and-insert

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -129,9 +129,9 @@ eval "$(starship init zsh)"
 # Fix zsh-abbr keybindings for vi mode
 if (( ${+functions[abbr]} )); then
     # Bind space to trigger abbreviation expansion in both modes
-    bindkey " " abbr-expand-and-space
-    bindkey -M viins " " abbr-expand-and-space
-    bindkey -M vicmd " " abbr-expand-and-space
+    bindkey " " abbr-expand-and-insert
+    bindkey -M viins " " abbr-expand-and-insert
+    bindkey -M vicmd " " abbr-expand-and-insert
 fi
 
 # proto


### PR DESCRIPTION
## Summary
- Fixed zsh-abbr widget binding that was causing "No such widget 'abbr-expand-and-space'" error
- Changed widget name from `abbr-expand-and-space` to `abbr-expand-and-insert` which is the correct widget provided by zsh-abbr

## Test plan
- [ ] Test abbreviation expansion by typing an abbreviation (e.g., `ll`) followed by space
- [ ] Verify no error messages appear when pressing space after abbreviations
- [ ] Confirm abbreviations expand correctly in both vi insert and command modes

🤖 Generated with [Claude Code](https://claude.ai/code)