### PR TITLE
:bug: fix(proto): update installation to use zsh-based installer

### DIFF
--- a/proto/README.md
+++ b/proto/README.md
@@ -20,7 +20,20 @@ Run the installation script:
 
 ### Requirements
 
-**Build essentials** are required for compiling Rust packages:
+1. **zsh** is required for the Proto installation script:
+
+```bash
+# Ubuntu/Debian
+sudo apt-get update && sudo apt-get install -y zsh
+
+# RHEL/CentOS/Fedora
+sudo yum install -y zsh
+
+# Arch Linux
+sudo pacman -S zsh
+```
+
+2. **Build essentials** are required for compiling Rust packages:
 
 ```bash
 # Ubuntu/Debian
@@ -32,8 +45,9 @@ sudo apt-get update && sudo apt-get install -y build-essential
 
 ### What the script does
 
+- **Checks for zsh** and provides installation instructions if missing
 - **Checks for build tools** and provides installation instructions
-- **Installs Proto** from the official installer script
+- **Installs Proto** using the official zsh-based installer
 - **Installs Rust** via Proto for package compilation
 - **Sets up environment** for current and future sessions
 

--- a/proto/install.sh
+++ b/proto/install.sh
@@ -30,10 +30,31 @@ if ! command -v cc >/dev/null 2>&1; then
     exit 1
 fi
 
+# Check if zsh is installed
+if ! command -v zsh >/dev/null 2>&1; then
+    echo "Error: zsh is required to install Proto."
+    echo ""
+    echo "Please install zsh first:"
+    
+    if command -v apt-get >/dev/null 2>&1; then
+        echo "  sudo apt-get update && sudo apt-get install -y zsh"
+    elif command -v yum >/dev/null 2>&1; then
+        echo "  sudo yum install -y zsh"
+    elif command -v pacman >/dev/null 2>&1; then
+        echo "  sudo pacman -S zsh"
+    else
+        echo "  Install zsh for your distribution"
+    fi
+    
+    echo ""
+    echo "After installing zsh, re-run this script."
+    exit 1
+fi
+
 # Install proto if not present
 if ! command -v proto >/dev/null 2>&1; then
     echo "Installing Proto..."
-    curl -fsSL https://moonrepo.dev/install/proto.sh | bash -s -- --yes
+    zsh <(curl -fsSL https://moonrepo.dev/install/proto.sh)
     
     # Proto is installed to a specific location
     PROTO_BIN="$HOME/.local/share/proto/bin/proto"


### PR DESCRIPTION
## Summary
- Fixed proto installation to use the correct zsh-based installer command
- Added zsh dependency check with platform-specific installation instructions
- Updated documentation to reflect zsh requirement

## Changes
- Modified `proto/install.sh` to check for zsh before installation
- Changed installation command from `bash` to `zsh <(curl ...)`
- Updated `proto/README.md` to document zsh as a requirement

## Test plan
- [ ] Verify proto installation works with zsh installed
- [ ] Confirm error message appears when zsh is missing
- [ ] Test installation instructions for different platforms

🤖 Generated with [Claude Code](https://claude.ai/code)