### PR TITLE
:wrench: chore(claude): add editor safety rules to jj skills and CLAUDE.md

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -26,6 +26,11 @@ Use the `jj-master` plugin skills and agents automatically as needed:
 - `jj-workspace` agent — Creates workspaces under `~/wkspace/worktree/<type>/`
 - `jj-github` agent — Creates PRs from jj repos
 
+### Editor Safety
+
+- **Always pass `-m`** to `jj squash`, `jj describe`, and any command that opens an editor
+- Without `-m`, jj spawns `$EDITOR` (nvim) which hangs forever in non-interactive shells
+
 ### Workflow
 
 - **New task**: Use `jj-workspace` agent to create a workspace

--- a/claude/marketplaces/local/plugins/jj-master/skills/jj-history/SKILL.md
+++ b/claude/marketplaces/local/plugins/jj-master/skills/jj-history/SKILL.md
@@ -16,21 +16,23 @@ No need for `git rebase --continue` - jj handles it.
 
 ## Squash (Combine Commits)
 
+**IMPORTANT**: Always pass `-m` to avoid opening an interactive editor (hangs in non-interactive shells).
+
 ```bash
 # Squash current into parent
-jj squash
+jj squash -m "message"
 
 # Squash specific commit into its parent
-jj squash -r <change-id>
+jj squash -r <change-id> -m "message"
 
 # Squash into specific destination
-jj squash --into <dest>
+jj squash --into <dest> -m "message"
 
 # Squash only specific files
-jj squash <file1> <file2>
+jj squash <file1> <file2> -m "message"
 
 # Interactive squash (select hunks)
-jj squash -i
+jj squash -i -m "message"
 ```
 
 ## Split (Break Apart Commits)
@@ -137,10 +139,9 @@ jj describe -m "new message"
 
 # Change specific commit message
 jj describe -r <change-id> -m "new message"
-
-# Open editor for message
-jj describe
 ```
+
+**Never** run `jj describe` without `-m` — it opens `$EDITOR` which hangs in non-interactive shells.
 
 ## Common Workflows
 
@@ -148,7 +149,7 @@ jj describe
 
 ```bash
 # Squash all WIP into one
-jj squash -r 'description(glob:"wip*")' --into @-
+jj squash -r 'description(glob:"wip*")' --into @- -m "combined WIP"
 ```
 
 ### Reorder Commits

--- a/claude/marketplaces/local/plugins/jj-master/skills/jj/SKILL.md
+++ b/claude/marketplaces/local/plugins/jj-master/skills/jj/SKILL.md
@@ -76,7 +76,7 @@ jj diff -r @-          # Parent's changes
 
 ```bash
 jj edit <id>           # Edit past commit
-jj squash              # Combine with parent
+jj squash -m "msg"     # Combine with parent (always use -m!)
 jj split               # Break commit apart
 jj rebase -d trunk()   # Update to latest
 jj absorb              # Smart change distribution
@@ -110,6 +110,11 @@ jj resolve <file>      # Interactive resolve
 jj resolve --tool=:ours   # Use our version
 jj resolve --tool=:theirs # Use their version
 ```
+
+### Editor Safety
+
+**IMPORTANT**: Always pass `-m` to commands that open an editor (`squash`, `describe`, `split`, `commit`).
+Without `-m`, jj spawns `$EDITOR` which hangs in non-interactive shells.
 
 ### Advanced Operations
 

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1775261198,
-        "narHash": "sha256-BdXWR+LoP8K0V71oT1pNXdlajowVxaLiXXeDXMdvLoM=",
+        "lastModified": 1775596386,
+        "narHash": "sha256-gm4uLwmMNxHse6ughtA2Oz6tdAbwDBAZ7q3l+Je9duo=",
         "owner": "ryoppippi",
         "repo": "claude-code-overlay",
-        "rev": "e4ec05a124e6a206e405091f245449291c58e8b6",
+        "rev": "a7b3970b0bb176f99e44572526ee5c6aee74fcfc",
         "type": "github"
       },
       "original": {
@@ -57,11 +57,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775457580,
-        "narHash": "sha256-ikws/ssAmG20AGrEwBuwspwPlkubJu34mB+Uz2fJBJs=",
+        "lastModified": 1775616747,
+        "narHash": "sha256-YdT9fCIuil4zkqJQyOMBpOEu/iHTyJhfVMS6ZYJ1mxs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5de7dbd151b0bd65d45785553d4a22d832733ffc",
+        "rev": "6f35bb97991f796f1f19734dc3db0f4c50b14e18",
         "type": "github"
       },
       "original": {
@@ -88,11 +88,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1775036866,
-        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "lastModified": 1775423009,
+        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Add "Editor Safety" section to global CLAUDE.md requiring `-m` flag on `jj squash`/`describe`
- Update all `jj squash` examples in jj-history skill to include `-m "message"`
- Add warning in jj skill quick reference about editor-opening commands
- Remove bare `jj describe` example that would hang in non-interactive shells

## Context
`jj squash` without `-m` opens `$EDITOR` (nvim) which hangs forever in non-interactive shells, causing stuck processes that need manual `kill -9`.

## Test plan
- [ ] Verify `claude /jj-history` shows updated squash examples with `-m`
- [ ] Verify `claude /jj` shows editor safety section
- [ ] Confirm CLAUDE.md includes the new editor safety rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)