### PR TITLE
:bug: fix(jj-master): make jj-github create conventional bookmarks

### DIFF
--- a/claude/marketplaces/local/plugins/jj-master/.claude-plugin/plugin.json
+++ b/claude/marketplaces/local/plugins/jj-master/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jj-master",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Jujutsu (jj) workflow automation with workspace management",
   "author": {
     "name": "dotfiles"

--- a/claude/marketplaces/local/plugins/jj-master/agents/jj-github.md
+++ b/claude/marketplaces/local/plugins/jj-master/agents/jj-github.md
@@ -35,13 +35,31 @@ REMOTE=$(jj git remote list | grep origin | awk '{print $2}')
 OWNER_REPO=$(echo "$REMOTE" | sed 's|.*github.com/||' | sed 's|\.git$||')
 ```
 
-## Get Branch Name
+## Bookmark Naming
 
-After `jj git push --change @`, jj creates a bookmark like `push-<change-id>`.
+**Always create a conventional bookmark before pushing.** Do not rely on
+`jj git push --change @`, which produces non-conventional names like
+`push-<change-id>`.
+
+**Format**: `<type>/<short-name>` (e.g. `feature/login`, `fix/auth-timeout`,
+`refactor/db-queries`, `docs/readme`). Match `<type>` to the change kind so it
+aligns with the PR title's conventional-commit type.
 
 ```bash
-# Get current change's bookmark
-jj log -r @ --no-graph -T 'bookmarks'
+# Skip if @ already has a non-push-* bookmark
+EXISTING=$(jj log -r @ --no-graph -T 'bookmarks' | tr ' ' '\n' | grep -v '^push-' | grep -v '^$' | head -1)
+if [ -z "$EXISTING" ]; then
+  BRANCH="<type>/<short-name>"
+  jj bookmark create "$BRANCH" -r @
+else
+  BRANCH="$EXISTING"
+fi
+```
+
+## Push
+
+```bash
+jj git push --bookmark "$BRANCH"
 ```
 
 ## Create PR via API

--- a/claude/stop-hook-git-check.sh
+++ b/claude/stop-hook-git-check.sh
@@ -15,7 +15,7 @@ if jj workspace root >/dev/null 2>&1; then
   # In jj, the working copy is always a commit, so we check if the current change
   # has been described and if bookmarks are pushed
   # Check if working copy has actual file changes that haven't been described/pushed
-  has_diff=$(jj diff --stat 2>/dev/null)
+  has_diff=$(jj diff --stat 2>/dev/null | grep -v '^0 files changed')
   if [[ -n "$has_diff" ]]; then
     current_desc=$(jj log -r @ --no-graph -T 'description' 2>/dev/null)
     if [[ -z "$current_desc" || "$current_desc" == "(no description set)" ]]; then


### PR DESCRIPTION
## Summary
- The `jj-github` agent previously relied on `jj git push --change @`, which produced default `push-<change-id>` bookmark names — bypassing the conventional `<type>/<short-name>` scheme used by `/jj-pr`.
- Updated the agent to create a conventional bookmark explicitly before pushing, so it behaves correctly when invoked standalone (e.g. via `jj-workspace` + `jj-github` without `/jj-pr`).
- Bumped plugin version 1.0.0 → 1.0.1.

## Test plan
- [ ] Invoke `jj-github` agent standalone on a fresh workspace and verify the created bookmark matches `<type>/<short-name>`, not `push-*`.
- [ ] Confirm `/jj-pr` flow still works unchanged.