### PR TITLE
:memo: docs(jj-master): add tutorial-derived idioms to skills

### DIFF
--- a/claude/marketplaces/local/plugins/jj-master/agents/jj-github.md
+++ b/claude/marketplaces/local/plugins/jj-master/agents/jj-github.md
@@ -59,8 +59,19 @@ fi
 ## Push
 
 ```bash
+# New bookmark: already created above, just push
+# Existing bookmark (updating a PR): move it first
+if jj log -r "$BRANCH" --no-graph -T 'change_id' >/dev/null 2>&1 \
+    && [ "$(jj log -r "$BRANCH" --no-graph -T 'change_id')" != "$(jj log -r @ --no-graph -T 'change_id')" ]; then
+  # Bookmark exists but points elsewhere — move it to @
+  jj bookmark set "$BRANCH" -r @ --allow-backwards
+fi
+
 jj git push --bookmark "$BRANCH"
 ```
+
+`jj git push` silently no-ops if no bookmark points at your new commits.
+Always verify with `jj log -r "$BRANCH"` before pushing.
 
 ## Create PR via API
 

--- a/claude/marketplaces/local/plugins/jj-master/skills/jj-history/SKILL.md
+++ b/claude/marketplaces/local/plugins/jj-master/skills/jj-history/SKILL.md
@@ -60,12 +60,36 @@ jj rebase -r <rev> -d <dest>
 # Rebase revision and descendants
 jj rebase -s <source> -d <dest>
 
+# Rebase a whole branch (revision + all descendants, like git's branch rebase)
+jj rebase -b <rev> -d <dest>
+
 # Rebase onto multiple parents (merge)
 jj rebase -d <parent1> -d <parent2>
 
 # Rebase onto trunk (update to latest)
 jj rebase -d trunk()
 ```
+
+**`-r` vs `-s` vs `-b`:**
+- `-r <rev>` — move only that single revision (descendants stay put, gap is closed)
+- `-s <rev>` — move revision + all its descendants
+- `-b <rev>` — move the whole branch containing `<rev>` (everything from trunk up to its heads)
+
+## Insert a Commit Before `@` (`-B`)
+
+When you realize mid-work that a prerequisite commit belongs *before* your
+current change, insert it without rewriting `@` manually:
+
+```bash
+# Insert empty commit before @, rebasing @ onto it automatically
+jj new -B @ -m "prep: refactor for upcoming change"
+
+# Make the prerequisite edits, then return to the original work:
+jj next --edit
+```
+
+`jj next --edit` moves `@` to the child change (vs. plain `jj next`, which
+creates a new child on top). Use `jj prev --edit` for the reverse.
 
 ## Edit (Modify Past Commits)
 

--- a/claude/marketplaces/local/plugins/jj-master/skills/jj-pr/SKILL.md
+++ b/claude/marketplaces/local/plugins/jj-master/skills/jj-pr/SKILL.md
@@ -51,6 +51,25 @@ Examples:
 - `refactor/db-queries`
 - `docs/readme-update`
 
+## Updating an Existing PR
+
+When pushing more commits to an already-open PR, **move** the bookmark rather
+than creating a new one:
+
+```bash
+# After new changes, move the bookmark to the new tip
+jj bookmark set <type>/<name> -r @
+
+# If moving to an ancestor (e.g. dropped a commit):
+jj bookmark set <type>/<name> -r @ --allow-backwards
+
+# Re-push (no --bookmark flag needed if only one tracked bookmark moved)
+jj git push --bookmark <type>/<name>
+```
+
+`jj git push` silently pushes nothing if the bookmark is not pointing at `@`.
+Always verify with `jj log` before pushing.
+
 ## PR Title Format
 
 Follow gitmoji + conventional commit with **mandatory scope**:

--- a/claude/marketplaces/local/plugins/jj-master/skills/jj-safety/SKILL.md
+++ b/claude/marketplaces/local/plugins/jj-master/skills/jj-safety/SKILL.md
@@ -93,6 +93,10 @@ side 2 content
 >>>>>>>
 ```
 
+Unlike git markers, the `%%%%%%%` section is a **diff** (base→side #1), not a
+full snapshot. The `+++++++` section is a full snapshot of side #2. To
+resolve, apply the diff's intent to side #2 (or vice versa).
+
 ## Workspace Safety
 
 ```bash

--- a/claude/marketplaces/local/plugins/jj-master/skills/jj/SKILL.md
+++ b/claude/marketplaces/local/plugins/jj-master/skills/jj/SKILL.md
@@ -60,6 +60,45 @@ jj git push --bookmark <type>/<name>
 # Create PR via gh api (see /jj-pr)
 ```
 
+## Updating Trunk from Upstream
+
+Bookmarks do **not** auto-follow `@` as git branches do. Update trunk explicitly.
+
+```bash
+# Fetch latest
+jj git fetch
+
+# Start new work on top of updated trunk
+jj new trunk()
+
+# Or rebase current stack onto new trunk
+jj rebase -d trunk()
+
+# Rebase all local branches at once (all:roots() handles multiple heads)
+jj rebase -s 'all:roots(trunk()..@)' -d 'trunk()'
+```
+
+## Bookmark: `create` vs `set`
+
+- `jj bookmark create <name> -r @` — create a new bookmark (fails if it exists)
+- `jj bookmark set <name> -r @` — move an existing bookmark (used when updating a PR)
+- `jj bookmark set <name> -r @ --allow-backwards` — required to move a bookmark to an ancestor
+
+## Squash vs Edit Workflow
+
+Two idiomatic patterns for building up a commit. Pick intentionally.
+
+**Squash workflow** (this project's default — mimics git's index):
+1. `jj describe -m "..."` on an empty `@` to name the work
+2. `jj new` to create a scratch commit above it
+3. Edit files, then `jj squash` (or `jj squash -i`) to move hunks into the described parent
+4. `@` stays empty; the parent accumulates the work
+
+**Edit workflow** (commits emerge as you go):
+1. `jj new -m "..."` — start work directly in `@`
+2. Mid-task, insert a prerequisite: `jj new -B @ -m "prep"` creates a commit *before* `@`; descendants auto-rebase
+3. `jj next --edit` to move back up the stack into the original commit
+
 ## Quick Reference
 
 ### Navigation & Viewing


### PR DESCRIPTION
## Summary

Adds tutorial-derived idioms and workflow patterns to jj-master plugin skills and jj-github agent, based on Steve Klabnik's jujutsu tutorial (HN #47763759):

- **jj/SKILL.md** — trunk-update flow, `bookmark create` vs `bookmark set`, Squash vs Edit workflow intro
- **jj-pr/SKILL.md** — PR update flow (bookmark set + re-push pattern)
- **jj-history/SKILL.md** — `jj new -B @` insert-before, `jj next --edit`, and `-r`/`-s`/`-b` rebase distinction
- **jj-safety/SKILL.md** — clarifies that `%%%%%%%` conflict section is a diff, not a snapshot
- **jj-github.md** — handle PR updates with `bookmark set --allow-backwards` before pushing

Source: Steve Klabnik's jujutsu tutorial and HN discussion #47763759