### PR TITLE
:memo: docs(claude): add Research & Search heuristics section

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -15,6 +15,20 @@
 - Use subagents for codebase exploration to avoid bloating main context
 - For large investigations, scope narrowly — don't read everything
 
+## Research & Search
+
+Use WebSearch liberally — prefer an extra query over relying on stale knowledge. When investigating options, architecture, or "what's current," widen the lens deliberately instead of searching the first phrase that comes to mind.
+
+Checklist for broadening a search:
+
+1. **Raise the abstraction level.** Search the underlying problem, not the assumed tool. ×「durable execution tools 2026」→ ○「how to run long-running business processes without adding infrastructure 2026」
+2. **Check recent papers.** arxiv / OpenReview, scoped to within the last year.
+3. **Negate the default premise.** "Do it all in Postgres", "WASM instead of X", "options that don't use RAG" — invert the assumption and search that.
+4. **Mix in regional / regulatory context.** 「日本」「sovereign」「on-prem」「airgapped」when relevant.
+5. **GitHub trending, filtered.** language × last 3 months × star growth.
+6. **Research-lab / product-group OSS.** AISI / Apple / Anthropic / DeepMind / NTT研 / 産総研.
+7. **"Death of X" / "why we stopped using X" postmortems.** Withdrawal writeups carry more signal than adoption writeups.
+
 ## Version Control: Jujutsu (jj)
 
 This environment uses **Jujutsu (jj)**, not git. **Never use git commands directly.**


### PR DESCRIPTION
## Summary

Adds a "Research & Search" section to claude/CLAUDE.md with 7 heuristics for broadening search scope:

- Raise the abstraction level to search the underlying problem
- Check recent papers (arxiv / OpenReview)
- Negate the default premise to invert assumptions
- Mix in regional / regulatory context when relevant
- Use GitHub trending filtered by language and timeframe
- Research lab and product-group OSS from various organizations
- Look for "death of X" postmortems with high signal

Also includes a note to use WebSearch more liberally instead of relying on stale knowledge.

## Testing

- No functional changes, documentation only
- Content follows project's Claude Code instruction conventions