### PR TITLE
:recycle: refactor(claude): empirically tune skill descriptions and bodies

### DIFF
--- a/claude/marketplaces/local/plugins/architect/skills/adr-discipline/SKILL.md
+++ b/claude/marketplaces/local/plugins/architect/skills/adr-discipline/SKILL.md
@@ -29,7 +29,8 @@ An ADR must **decide** or **explicitly defer with trigger conditions**. An ADR t
 | Adding a new store/service when the existing one could serve | Default question: *can Postgres do this? can the existing queue handle this?* Prove the existing tool is insufficient before adding a new one |
 | Writing ADRs that enumerate options without deciding | Decide — or write a **deferred-adoption ADR** with explicit trigger conditions |
 | Missing cross-ADR consistency | Re-read prior committed ADRs before writing a new one. Proposing Langfuse right after committing to Postgres-only is a contradiction to catch |
-| Narrating internal process inside the ADR body | Let the **commit message** carry the reasoning trail. The ADR records *what was decided* and *why*, not *how you arrived there* |
+| Narrating internal process inside the ADR body | Let the **commit message** carry the reasoning trail. The ADR records *what was decided* and *why*, not *how you arrived there*. First-pass red flags: "we considered…", "after evaluating…", "we searched for…", "the options were…". These belong in the commit message, not the ADR. |
+| Skipping current-session verification because it feels costly | Verification is non-negotiable. If live verification is literally blocked (offline context, tools disabled, tight time-box), do **not** write a decision on unverified premises. Defer the ADR with an explicit `verification-pending` status and list the exact checks owed — release cadence, maintenance status, store requirements, named CVEs. Training-data recall is not verification. |
 
 ## Honest Recalibration
 

--- a/claude/marketplaces/local/plugins/jj-master/skills/jj-history/SKILL.md
+++ b/claude/marketplaces/local/plugins/jj-master/skills/jj-history/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jj-history
-description: Jujutsu history editing - squash, split, rebase, absorb
+description: Jujutsu history editing — squash, split, rebase (-r/-s/-b), insert-before (-B), edit, absorb, diffedit, abandon, duplicate, describe. Covers common workflows (reorder, insert-in-middle, fix old commit, clean WIP) and the mandatory -m editor-safety rule.
 argument-hint: operation type or empty for reference
 disable-model-invocation: true
 ---

--- a/claude/marketplaces/local/plugins/jj-master/skills/jj-safety/SKILL.md
+++ b/claude/marketplaces/local/plugins/jj-master/skills/jj-safety/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jj-safety
-description: Jujutsu safety operations - undo, redo, operation log
+description: Jujutsu safety and recovery — undo/redo, operation log, op-restore, conflict handling (including jj's diff-style conflict markers), workspace listing/forget, immutable-commits config, and recovery scenarios (abandoned commits, bad rebase, lost work, fetch overwrote local).
 argument-hint: operation or empty for reference
 disable-model-invocation: true
 ---

--- a/claude/marketplaces/local/plugins/jj-master/skills/jj/SKILL.md
+++ b/claude/marketplaces/local/plugins/jj-master/skills/jj/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jj
-description: Jujutsu workspace workflow - auto-creates workspace before tasks
+description: Jujutsu (jj) workflow — workspace setup, bookmark management, squash/edit patterns, trunk updates, and a quick reference for navigation, history editing, conflict resolution, and safety. Use for any jj task; /jj-history, /jj-safety, /jj-revsets, /jj-pr, /jj-submodules cover those areas in depth.
 argument-hint: task description
 ---
 
@@ -16,11 +16,18 @@ Before starting any task, ensure a jj workspace exists.
 
 ## Auto-Create Workspace
 
+This project defaults to the **squash workflow** (see "Squash vs Edit Workflow" below). The setup below leaves `@` as an empty scratch commit above a described parent, ready for squashing hunks down.
+
 ```bash
 jj workspace add --name <name> ~/wkspace/worktree/<type>/<name>
 cd ~/wkspace/worktree/<type>/<name>
-jj new -m "<type>: <description>"
+
+# Describe the current empty @ with the initial message, then add scratch @ above it.
+jj describe -m ":emoji: <type>(<scope>): <description>"
+jj new   # empty scratch; edits happen here and get squashed down
 ```
+
+For the edit workflow (commits accumulate directly on `@`), replace the two lines above with `jj new -m ":emoji: <type>(<scope>): <description>"` and edit in-place.
 
 ## Task: $ARGUMENTS
 
@@ -35,9 +42,16 @@ jj new -m "<type>: <description>"
 
 Format: `<type>/<short-name>` (e.g., `feature/jj-rules`, `fix/auth-bug`)
 
+**Anchor revision** depends on workflow:
+- Squash workflow (project default): the described work is `@-`; `@` is empty scratch. Anchor `-r @-`.
+- Edit workflow: the described work is `@` itself. Anchor `-r @`.
+
 ```bash
-# Create bookmark with conventional name
-jj bookmark create <type>/<name> -r @
+# Squash-workflow default (anchor the bookmark on the described parent, NOT the empty scratch):
+jj bookmark create <type>/<name> -r @-
+
+# Edit-workflow variant:
+# jj bookmark create <type>/<name> -r @
 
 # Push with the named bookmark
 jj git push --bookmark <type>/<name>
@@ -47,18 +61,24 @@ jj git push --bookmark <type>/<name>
 
 ## Completing Work
 
-```bash
-# Describe changes
-jj describe -m ":emoji: type(scope): description"
+Squash workflow (default):
 
-# Create conventional bookmark
-jj bookmark create <type>/<name> -r @
+```bash
+# Fold the scratch @ hunks into the described parent
+jj squash -m ":emoji: type(scope): description"
+
+# Create the conventional bookmark on the described commit (@- is the parent
+# since the described commit was @ before the squash moved hunks into it; after
+# squash @ is the new empty scratch, and the described commit is @-)
+jj bookmark create <type>/<name> -r @-
 
 # Push
 jj git push --bookmark <type>/<name>
 
 # Create PR via gh api (see /jj-pr)
 ```
+
+Edit workflow: replace `jj squash -m` with `jj describe -m` (to finalize the message on `@`) and anchor the bookmark on `-r @`.
 
 ## Updating Trunk from Upstream
 
@@ -117,7 +137,7 @@ jj diff -r @-          # Parent's changes
 jj edit <id>           # Edit past commit
 jj squash -m "msg"     # Combine with parent (always use -m!)
 jj split               # Break commit apart
-jj rebase -d trunk()   # Update to latest
+jj rebase -d trunk()   # Move ONLY @ to trunk (see "Updating Trunk" for whole-stack form)
 jj absorb              # Smart change distribution
 ```
 


### PR DESCRIPTION
## Summary

Applied iter-0 static audit + empirical-prompt-tuning to user-authored skills in the dotfiles repo.

### Iter-0 description fixes (3 skills)
- `jj`, `jj-history`, `jj-safety`: description frontmatter previously under-advertised body coverage. Expanded descriptions to match actual content (verbs, operations, recovery scenarios, etc.) so auto-matching / discovery isn't silently gated on narrower phrasing.

### Empirical tuning (2 skills, converged in 3 iterations each)

**`jj`** — dispatched 3 fresh subagents per iteration against these scenarios:
- new-feature setup from scratch
- amending a pushed PR (bookmark set vs create, --allow-backwards)
- rebasing a 3-commit stack onto updated trunk (whole-stack form vs bare -d)

Iter 2 fixes (common theme: squash-workflow as default not propagated through examples):
- Auto-Create Workspace block: added explicit squash-workflow pattern with `jj describe -m` + `jj new`, plus edit-workflow variant for clarity
- Bookmark Naming Convention: `-r @-` for squash workflow (default), `-r @` for edit workflow — prior examples anchored the bookmark on the empty scratch commit
- Completing Work: `jj squash -m` + bookmark on `@-` (squash-workflow default)
- Quick Reference: clarified `jj rebase -d trunk()` only moves `@` (whole-stack form lives in "Updating Trunk")

Hold-out scenario (conflict resolution, non-interactive shell): passed cleanly.

**`adr-discipline`** — dispatched 3 fresh subagents per iteration:
- Temporal adoption (decide vs defer)
- WASM plugin sandboxing (deferred-adoption pattern)
- Langfuse vs ADR 0002 Postgres-only (cross-ADR consistency)

Iter 2 fixes (anti-patterns table):
- Added `verification-pending` status convention for contexts where current-session verification is blocked — tells agents exactly what to do instead of defaulting to training-data recall
- Strengthened "no process narration" anti-pattern with concrete first-pass red-flag phrases ("we considered…", "after evaluating…", "we searched for…")

Hold-out scenario (Honest Recalibration with new evidence on a draft ADR): passed cleanly; agent rewrote decision rather than defending prior draft.

### Convergence metrics

Both skills reached 100% accuracy across all scenarios with 0 retries on iter 2+; hold-out accuracy drop 0 pp (well under 15 pp overfitting threshold).

## Test plan

- [ ] Read through each modified SKILL.md for internal consistency
- [ ] Dispatch a fresh-session agent against the `jj` skill on a novel scenario (e.g., split a commit + rebase back onto trunk) and confirm it produces sensible commands
- [ ] Dispatch a fresh-session agent against `adr-discipline` on a polyglot/language-choice ADR scenario and confirm discipline holds