### PR TITLE
:sparkles: feat(claude): add WSL clipboard image bridge for Claude Code

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -78,6 +78,17 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/wsl-clipboard-image-hook.sh"
+          }
+        ]
+      }
     ]
   },
   "enabledPlugins": {

--- a/claude/wsl-clipboard-image-hook.sh
+++ b/claude/wsl-clipboard-image-hook.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# UserPromptSubmit hook: when the prompt contains the sentinel `@clip`,
+# extract the current Windows clipboard image via PowerShell, save it to
+# ~/.claude/paste-cache/, and tell the model where it lives via
+# additionalContext. WSL-only; silently no-ops elsewhere.
+
+set -u
+
+SENTINEL='@clip'
+CACHE_DIR="${HOME}/.claude/paste-cache"
+
+input=$(cat)
+prompt=$(printf '%s' "$input" | jq -r '.prompt // ""')
+
+case "$prompt" in
+  *"$SENTINEL"*) ;;
+  *) exit 0 ;;
+esac
+
+command -v powershell.exe >/dev/null 2>&1 || exit 0
+command -v wslpath        >/dev/null 2>&1 || exit 0
+
+mkdir -p "$CACHE_DIR"
+filename="clip-$(date +%Y%m%d-%H%M%S-%N).png"
+linux_path="${CACHE_DIR}/${filename}"
+win_path=$(wslpath -w "$linux_path")
+win_path_escaped=${win_path//\\/\\\\}
+
+ps_script=$(cat <<PS
+Add-Type -AssemblyName System.Windows.Forms
+\$img = [System.Windows.Forms.Clipboard]::GetImage()
+if (\$img) {
+  \$img.Save('${win_path_escaped}', [System.Drawing.Imaging.ImageFormat]::Png)
+  exit 0
+} else {
+  exit 1
+}
+PS
+)
+
+if ! powershell.exe -sta -NoProfile -Command "$ps_script" >/dev/null 2>&1; then
+  jq -n --arg s "$SENTINEL" '{
+    hookSpecificOutput: {
+      hookEventName: "UserPromptSubmit",
+      additionalContext: "Sentinel \($s) was used but the Windows clipboard did not contain an image. Ask the user to copy an image (e.g. Win+Shift+S) and try again."
+    }
+  }'
+  exit 0
+fi
+
+jq -n --arg p "$linux_path" --arg s "$SENTINEL" '{
+  hookSpecificOutput: {
+    hookEventName: "UserPromptSubmit",
+    additionalContext: "Sentinel \($s) triggered a Windows→WSL clipboard image bridge. The image is saved at: \($p)\nRead this file to see what the user pasted."
+  }
+}'

--- a/modules/claude-code.nix
+++ b/modules/claude-code.nix
@@ -10,6 +10,7 @@ in
   home.file.".claude/CLAUDE.md".source = mkSymlink "${dotfilesClaudePath}/CLAUDE.md";
   home.file.".claude/stop-hook-git-check.sh".source = mkSymlink "${dotfilesClaudePath}/stop-hook-git-check.sh";
   home.file.".claude/stop-phrase-guard.sh".source = mkSymlink "${dotfilesClaudePath}/stop-phrase-guard.sh";
+  home.file.".claude/wsl-clipboard-image-hook.sh".source = mkSymlink "${dotfilesClaudePath}/wsl-clipboard-image-hook.sh";
 
   # Run marketplace plugin setup after build
   home.activation.setupClaudeCode = lib.hm.dag.entryAfter [ "writeBoundary" ] ''

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -10,6 +10,11 @@
   wsl.enable = true;
   wsl.defaultUser = "nixos";
 
+  # Explicitly register the WSLInterop binfmt handler so Windows .exe files
+  # (powershell.exe, clip.exe, etc.) are directly executable from bash.
+  # Required for the `wsl-clipboard-image-hook.sh` Windows→WSL image bridge.
+  wsl.interop.register = true;
+
   # vkms kernel module (requires custom WSL2 kernel with CONFIG_DRM_VKMS=m)
   boot.kernelModules = [ "vkms" ];
 


### PR DESCRIPTION
## Summary

- New `UserPromptSubmit` hook `claude/wsl-clipboard-image-hook.sh`: detects sentinel `@clip` in a prompt, saves the current Windows-clipboard image to `~/.claude/paste-cache/clip-<ts>.png` via `powershell.exe -sta`, and injects the file path as `additionalContext` so the model can read it.
- Hook is silently skipped when `@clip` is absent or when `powershell.exe`/`wslpath` aren't on `PATH`.
- Enables `wsl.interop.register` in `nixos/configuration.nix` — on this NixOS-WSL install, `WSLInterop` isn't registered by default, which is what blocks `powershell.exe` execution from bash.

## How to activate (post-merge)

1. `home-manager switch --flake .` — picks up the new hook script + settings.
2. `sudo cp nixos/configuration.nix /etc/nixos/configuration.nix && sudo nixos-rebuild switch` — registers `WSLInterop`.
3. **`wsl --shutdown` from Windows PowerShell** — `binfmt_misc` changes only take effect after the WSL VM restarts.
4. Verify with `ls /proc/sys/fs/binfmt_misc/WSLInterop*` (should exist) and `powershell.exe -Command "echo hi"` (should print `hi`).

## Usage

Put an image on the Windows clipboard (e.g. `Win+Shift+S`), then type `@clip` anywhere in your prompt. The hook saves the image under `~/.claude/paste-cache/` and tells the model to read it.

## Test plan

- [ ] `home-manager switch --flake .` succeeds
- [ ] `sudo nixos-rebuild switch` succeeds after copying the reference config
- [ ] After `wsl --shutdown`, `/proc/sys/fs/binfmt_misc/WSLInterop` exists
- [ ] Prompt without `@clip` → hook exits 0, no additional context (already smoke-tested)
- [ ] Prompt with `@clip` + empty clipboard → hook reports "clipboard did not contain an image" (already smoke-tested locally before the interop fix)
- [ ] Prompt with `@clip` + screenshot on clipboard → image saved under `~/.claude/paste-cache/`, path injected as additional context