### PR TITLE
:sparkles: feat(claude): add ast-grep for AST-aware code search

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -17,6 +17,7 @@
       "Bash(env)",
       "Bash(tree:*)",
       "Bash(wc:*)",
+      "Bash(ast-grep:*)",
       "Bash(git status:*)",
       "Bash(git log:*)",
       "Bash(git diff:*)",

--- a/home.nix
+++ b/home.nix
@@ -37,6 +37,7 @@ in
     yazi       # Terminal file manager
     fd         # Modern find replacement
     ripgrep    # Modern grep replacement
+    ast-grep   # AST-aware structural code search
     fzf        # Fuzzy finder
     bat        # Better cat
     delta      # Better git diff


### PR DESCRIPTION
## Summary

- Adds `ast-grep` (v0.42.1) to `home.packages` for AST-aware structural code search alongside ripgrep/fd
- Whitelists `Bash(ast-grep:*)` in `claude/settings.json` so Claude Code can invoke it without prompts
- Motivated by lightweight code-intelligence improvements (a structural alternative to text-grep, without an MCP daemon)

## Verification

- Verified locally: `home-manager switch --flake .#nixos@wsl` succeeded
- `ast-grep --version` returns 0.42.1

🤖 Generated with Claude Code