### PR TITLE
:sparkles: feat(home): add podman container engine

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -58,6 +58,9 @@ in
     ghq        # Git repository manager
     claude-code # Claude AI coding assistant (native binary via ryoppippi/claude-code-overlay)
 
+    # Containers
+    podman     # Daemonless container engine (docker-compatible CLI)
+
     # Nix tools
     nixpkgs-fmt # Nix formatter
     nil        # Nix LSP


### PR DESCRIPTION
## Summary

- Add podman (daemonless container engine) to home.packages for docker-compatible CLI usage

## Test plan

- [x] home-manager switch completed successfully
- [x] podman --version reports 5.8.1