### PR TITLE
:sparkles: feat(nixos): enable podman virtualisation with docker compat

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -54,5 +54,14 @@
     seatd
   ];
 
+  # Podman: rootless container engine with docker CLI compatibility.
+  # dockerCompat aliases `docker` -> podman and exposes /var/run/docker.sock.
+  # dns_enabled is required for inter-container name resolution under compose.
+  virtualisation.podman = {
+    enable = true;
+    dockerCompat = true;
+    defaultNetwork.settings.dns_enabled = true;
+  };
+
   system.stateVersion = "25.05";
 }


### PR DESCRIPTION
## Summary
- Enables `virtualisation.podman` at the NixOS system level so the `podman` CLI added in #148 can actually run containers (subuid/subgid maps, `/run/podman/podman.sock`, networking).
- `dockerCompat = true` aliases `docker` → `podman` and exposes `/var/run/docker.sock` so docker-compose / testcontainers / IDE plugins work unchanged.
- `defaultNetwork.settings.dns_enabled = true` enables `aardvark-dns` so containers on user-defined networks can resolve each other by service name (required for compose).

## Deployment note
`nixos/configuration.nix` is a reference copy — it must be `sudo cp`'d to `/etc/nixos/configuration.nix` and applied with `sudo nixos-rebuild switch` to take effect (see comment at top of the file).

## Test plan
- [ ] `sudo cp nixos/configuration.nix /etc/nixos/configuration.nix && sudo nixos-rebuild switch`
- [ ] `systemctl status podman.socket` shows active
- [ ] `podman run --rm hello-world` succeeds rootless
- [ ] `docker --version` resolves (via dockerCompat alias)
- [ ] `docker compose up` on a multi-service file resolves containers by service name