### PR TITLE
:memo: docs(jj-master): auto-detect existing PR before creating

### DIFF
--- a/claude/marketplaces/local/plugins/jj-master/agents/jj-github.md
+++ b/claude/marketplaces/local/plugins/jj-master/agents/jj-github.md
@@ -73,7 +73,24 @@ jj git push --bookmark "$BRANCH"
 `jj git push` silently no-ops if no bookmark points at your new commits.
 Always verify with `jj log -r "$BRANCH"` before pushing.
 
-## Create PR via API
+## Check for Existing PR (REQUIRED before creating)
+
+A bookmark may already have an open PR from a prior run. Creating a duplicate
+fails with a 422 from the API. Always check first:
+
+```bash
+# Works without .git because --repo bypasses local repo detection
+EXISTING_PR=$(gh pr list --repo "$OWNER_REPO" --head "$BRANCH" --state open \
+  --json url --jq '.[0].url // empty')
+
+if [ -n "$EXISTING_PR" ]; then
+  echo "PR already exists for $BRANCH: $EXISTING_PR"
+  echo "Push above updated it with the new commits — no creation needed."
+  exit 0
+fi
+```
+
+## Create PR via API (only if no existing PR)
 
 ```bash
 gh api repos/$OWNER_REPO/pulls \
@@ -85,4 +102,5 @@ gh api repos/$OWNER_REPO/pulls \
 
 ## Output
 
-Return the PR URL from the API response.
+Return the PR URL — either the freshly created one, or the existing one
+detected above (mark it as `(updated)` so the caller knows it wasn't new).

--- a/claude/marketplaces/local/plugins/jj-master/skills/jj-pr/SKILL.md
+++ b/claude/marketplaces/local/plugins/jj-master/skills/jj-pr/SKILL.md
@@ -32,7 +32,21 @@ disable-model-invocation: true
    OWNER_REPO=$(echo "$REMOTE" | sed 's|.*github.com[:/]||' | sed 's|\.git$||')
    ```
 
-5. **Create PR via API**
+5. **Check for existing PR** (skip creation if one already exists)
+   ```bash
+   EXISTING_PR=$(gh pr list --repo "$OWNER_REPO" --head "<type>/<name>" \
+     --state open --json url --jq '.[0].url // empty')
+
+   if [ -n "$EXISTING_PR" ]; then
+     echo "PR already exists: $EXISTING_PR (updated by push above)"
+     # Done — no need to create
+   fi
+   ```
+
+   `gh pr list --repo …` works without `.git`, so this is safe in pure jj
+   workspaces. If `$EXISTING_PR` is empty, fall through to step 6.
+
+6. **Create PR via API** (only if no existing PR)
    ```bash
    gh api repos/$OWNER_REPO/pulls \
      -f title="$TITLE" \


### PR DESCRIPTION
## Summary
- Add explicit "check for existing PR" step in both the `jj-github` agent and `/jj-pr` skill, using `gh pr list --repo … --head … --state open` so it works in pure-jj workspaces (no `.git`).
- Skip `gh api repos/.../pulls` creation if a PR already exists for the bookmark; the prior `jj git push` already updated the existing PR with new commits.
- Return the existing PR URL marked `(updated)` so callers know it wasn't freshly created.

## Test plan
- [x] Dogfooded by this PR itself: the `jj-github` agent ran the new check before attempting creation.
- [ ] Re-run jj-github on the same bookmark after merge; verify it reports the existing PR instead of erroring with 422.