### PR TITLE
:sparkles: feat(nvim): upgrade LSPs (basedpyright+ruff, vtsls) and formatters (oxfmt, nixfmt, gofumpt)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1778873347,
-        "narHash": "sha256-SvAVQsHI/co9dxqbS2IAGa7EETFZS44M7Ehzzz1zaKs=",
+        "lastModified": 1779569414,
+        "narHash": "sha256-6Tgl9dIDkHa7KX7MID0hkVEaryR8OMWrcV43bdWEOmw=",
         "owner": "ryoppippi",
         "repo": "claude-code-overlay",
-        "rev": "f93a8bb73129fc5a45b10cb4d8ee8432cef3d3d2",
+        "rev": "6b5a0e9bee689f0f21ad9f19c19a359ebe0593e0",
         "type": "github"
       },
       "original": {
@@ -57,11 +57,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779027260,
-        "narHash": "sha256-ZbgWWFQmSyM3HQ31nAZk2hJ7OSeNr9uRFHL8jCifY9M=",
+        "lastModified": 1779726696,
+        "narHash": "sha256-/p37CB5n6Wpw250b0Lq0CYwNq2D8uGKzDoBulyLcQqA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bcb774cfc3268120cd61808629f9aa7dad3750a2",
+        "rev": "1a95e2efb477959b70b4a14c51035975c0481df6",
         "type": "github"
       },
       "original": {
@@ -88,11 +88,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {

--- a/modules/neovim.nix
+++ b/modules/neovim.nix
@@ -14,19 +14,22 @@
       lua-language-server
       nil # Nix LSP
       bash-language-server
-      typescript-language-server
+      vtsls # TypeScript/JavaScript LSP (VSCode's tsserver wrapper)
       vscode-langservers-extracted # HTML, CSS, JSON, ESLint
       yaml-language-server
-      python3Packages.python-lsp-server
+      basedpyright # Python LSP (pyright fork with stricter defaults)
+      ruff # Python linter + formatter (native LSP via `ruff server`)
       rust-analyzer
       gopls
 
       # Formatters
-      nixpkgs-fmt
+      nixfmt # Official Nix formatter (RFC 166) — was nixfmt-rfc-style, now aliased
       shfmt
-      prettierd
-      black
+      oxfmt # JS/TS/JSON formatter (Rust, prettier-compatible output → zero style churn)
+      prettierd # Used for CSS/SCSS/HTML/YAML/Markdown (oxfmt doesn't cover those yet)
+      gofumpt # Stricter superset of gofmt
       rustfmt
+      stylua # Lua formatter (used by conform)
 
       # Tools
       ripgrep

--- a/nvim/lua/config/autocmds.lua
+++ b/nvim/lua/config/autocmds.lua
@@ -151,10 +151,17 @@ autocmd("LspAttach", {
     map('<leader>ci', '<cmd>Lspsaga incoming_calls<cr>', 'Incoming Calls')
     map('<leader>co', '<cmd>Lspsaga outgoing_calls<cr>', 'Outgoing Calls')
 
-    -- Mini.pick for symbols
-    map('<leader>D', require('mini.pick').builtin.lsp({ scope = 'type_definition' }), 'Type Definition')
-    map('<leader>ds', require('mini.pick').builtin.lsp({ scope = 'document_symbol' }), 'Document Symbols')
-    map('<leader>ws', require('mini.pick').builtin.lsp({ scope = 'workspace_symbol' }), 'Workspace Symbols')
+    -- Mini.extra pickers for LSP symbols
+    -- (wrapped in functions so the picker is invoked on keypress, not at LspAttach)
+    map('<leader>D', function()
+      require('mini.extra').pickers.lsp({ scope = 'type_definition' })
+    end, 'Type Definition')
+    map('<leader>ds', function()
+      require('mini.extra').pickers.lsp({ scope = 'document_symbol' })
+    end, 'Document Symbols')
+    map('<leader>ws', function()
+      require('mini.extra').pickers.lsp({ scope = 'workspace_symbol' })
+    end, 'Workspace Symbols')
 
     -- Workspace folder management
     map('<leader>wa', vim.lsp.buf.add_workspace_folder, 'Workspace Add Folder')

--- a/nvim/lua/config/format.lua
+++ b/nvim/lua/config/format.lua
@@ -15,8 +15,8 @@ M.setup = function()
       -- Lua
       lua = { 'stylua' },
 
-      -- Nix
-      nix = { 'nixpkgs_fmt' },
+      -- Nix (official RFC 166 formatter)
+      nix = { 'nixfmt' },
 
       -- Shell
       sh = { 'shfmt' },
@@ -24,27 +24,27 @@ M.setup = function()
       zsh = { 'shfmt' },
       fish = { 'fish_indent' },
 
-      -- Python
-      python = { 'black' },
+      -- Python (ruff handles both linting and formatting)
+      python = { 'ruff_organize_imports', 'ruff_format' },
 
       -- Rust
       rust = { 'rustfmt' },
 
-      -- Go
-      go = { 'gofmt', 'goimports' },
+      -- Go (gofumpt = strict superset of gofmt; goimports for import sorting)
+      go = { 'gofumpt', 'goimports' },
 
-      -- JavaScript/TypeScript
-      javascript = { 'prettier' },
-      typescript = { 'prettier' },
-      javascriptreact = { 'prettier' },
-      typescriptreact = { 'prettier' },
+      -- JavaScript/TypeScript (oxfmt = prettier-compatible output, Rust-fast)
+      javascript = { 'oxfmt' },
+      typescript = { 'oxfmt' },
+      javascriptreact = { 'oxfmt' },
+      typescriptreact = { 'oxfmt' },
 
-      -- Web
-      html = { 'prettier' },
+      -- Web (oxfmt covers JSON; prettier covers CSS/SCSS/HTML/YAML/MD)
+      json = { 'oxfmt' },
+      jsonc = { 'oxfmt' },
       css = { 'prettier' },
       scss = { 'prettier' },
-      json = { 'prettier' },
-      jsonc = { 'prettier' },
+      html = { 'prettier' },
       yaml = { 'prettier' },
       markdown = { 'prettier' },
 

--- a/nvim/lua/config/lsp.lua
+++ b/nvim/lua/config/lsp.lua
@@ -29,7 +29,7 @@ local server_configs = {
     settings = {
       ['nil'] = {
         formatting = {
-          command = { 'nixpkgs-fmt' },
+          command = { 'nixfmt' },
         },
         nix = {
           flake = {
@@ -40,15 +40,37 @@ local server_configs = {
     },
   },
 
-  -- Python
-  pyright = {
+  -- Python: basedpyright handles type checking, completion, navigation
+  basedpyright = {
+    cmd = { 'basedpyright-langserver', '--stdio' },
+    filetypes = { 'python' },
+    root_markers = { 'pyproject.toml', 'setup.py', 'setup.cfg', 'requirements.txt', 'Pipfile', 'pyrightconfig.json', '.git' },
     settings = {
-      python = {
+      basedpyright = {
         analysis = {
           typeCheckingMode = 'basic',
           autoSearchPaths = true,
           useLibraryCodeForTypes = true,
+          diagnosticMode = 'openFilesOnly',
+          -- Defer linting to ruff to avoid duplicate diagnostics
+          diagnosticSeverityOverrides = {
+            reportUnusedImport = 'none',
+            reportUnusedVariable = 'none',
+          },
         },
+      },
+    },
+  },
+
+  -- Python: ruff provides fast linting + organize imports via LSP
+  ruff = {
+    cmd = { 'ruff', 'server' },
+    filetypes = { 'python' },
+    root_markers = { 'pyproject.toml', 'ruff.toml', '.ruff.toml', '.git' },
+    init_options = {
+      settings = {
+        -- Disable hover from ruff so basedpyright owns it
+        hover = { enable = false },
       },
     },
   },
@@ -67,8 +89,38 @@ local server_configs = {
     },
   },
 
-  -- TypeScript/JavaScript
-  ts_ls = {},
+  -- TypeScript/JavaScript: vtsls = VSCode's TS LSP wrapper
+  -- (richer auto-imports, code actions, organize-imports vs ts_ls)
+  vtsls = {
+    cmd = { 'vtsls', '--stdio' },
+    filetypes = { 'javascript', 'javascriptreact', 'javascript.jsx', 'typescript', 'typescriptreact', 'typescript.tsx' },
+    root_markers = { 'tsconfig.json', 'jsconfig.json', 'package.json', '.git' },
+    settings = {
+      typescript = {
+        updateImportsOnFileMove = { enabled = 'always' },
+        suggest = { completeFunctionCalls = true },
+        inlayHints = {
+          parameterNames = { enabled = 'literals' },
+          parameterTypes = { enabled = true },
+          variableTypes = { enabled = false },
+          propertyDeclarationTypes = { enabled = true },
+          functionLikeReturnTypes = { enabled = true },
+          enumMemberValues = { enabled = true },
+        },
+      },
+      javascript = {
+        updateImportsOnFileMove = { enabled = 'always' },
+        suggest = { completeFunctionCalls = true },
+      },
+      vtsls = {
+        enableMoveToFileCodeAction = true,
+        autoUseWorkspaceTsdk = true,
+        experimental = {
+          completion = { enableServerSideFuzzyMatch = true },
+        },
+      },
+    },
+  },
 
   -- Go
   gopls = {
@@ -121,9 +173,10 @@ local server_configs = {
 local server_executables = {
   lua_ls = 'lua-language-server',
   nil_ls = 'nil',
-  pyright = 'pyright-langserver',
+  basedpyright = 'basedpyright-langserver',
+  ruff = 'ruff',
   rust_analyzer = 'rust-analyzer',
-  ts_ls = 'typescript-language-server',
+  vtsls = 'vtsls',
   gopls = 'gopls',
   bashls = 'bash-language-server',
   jsonls = 'vscode-json-language-server',


### PR DESCRIPTION
## Summary

Modernizes the Neovim LSP + formatter stack.

### LSP
- **Python**: `pylsp` → **basedpyright** (type checking, completion, navigation) + **ruff** (fast lint diagnostics + organize-imports via native `ruff server`). Diagnostic severity for `reportUnusedImport`/`reportUnusedVariable` is silenced on basedpyright to avoid duplicate warnings with ruff.
- **TypeScript/JavaScript**: `ts_ls` → **vtsls** (VSCode's tsserver wrapper; richer auto-imports, inlay hints, organize-imports, move-to-file code action).

### Formatters
- **JS/TS/JSON**: `prettier` → **oxfmt** (Rust, prettier-compatible output — no style churn when editing other people's repos).
- **CSS/SCSS/HTML/YAML/Markdown**: still `prettier` (oxfmt doesn't cover those yet).
- **Nix**: `nixpkgs-fmt` → **nixfmt** (RFC 166 official). `nil_ls` formatting command updated accordingly.
- **Go**: `gofmt` → **gofumpt** (stricter superset, no opt-out cost).
- **Python**: `black` → **ruff_organize_imports + ruff_format**.
- Explicit `stylua` in `extraPackages` (was implicitly expected by conform).

### Bug fix
- LSP symbol pickers in `autocmds.lua` were calling `require('mini.pick').builtin.lsp(...)` (wrong API — that field doesn't exist, threw on LspAttach). Switched to `require('mini.extra').pickers.lsp(...)` and wrapped in functions so the picker opens on keypress, not at attach time.

## Test plan
- [x] `nix flake check` passes
- [x] `home-manager switch --flake .#nixos@wsl` applies cleanly
- [x] All formatter binaries resolve inside nvim: `oxfmt`, `nixfmt`, `gofumpt`, `stylua`, `ruff`, `shfmt`, `prettierd`, `rustfmt`
- [x] Python: both `basedpyright` and `ruff` LSPs attach on `.py` buffer
- [x] TypeScript: `vtsls` attaches on `.ts` buffer
- [x] oxfmt formats `.ts` and `.json` samples
- [x] nixfmt formats `.nix` sample
- [x] gofumpt formats `.go` sample
- [x] No more `LspAttach Autocommands` runtime errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)