### PR TITLE
:sparkles: feat(home): add gh-dash TUI dashboard for GitHub

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -55,6 +55,7 @@ in
     # Development tools
     git-lfs    # Git Large File Storage
     gh         # GitHub CLI
+    gh-dash    # TUI dashboard for GitHub PRs and issues
     ghq        # Git repository manager
     claude-code # Claude AI coding assistant (native binary via ryoppippi/claude-code-overlay)
 


### PR DESCRIPTION
## Summary

Add `gh-dash` package to the Development tools section of home.nix. This TUI dashboard provides an efficient interface for managing GitHub PRs and issues.

## Verification

- `nix flake check` passes
- `home-manager switch --flake .#nixos@wsl` succeeds
- `gh-dash --version` runs successfully from user profile

Generated with [Claude Code](https://claude.com/claude-code)