### PR TITLE
:sparkles: feat(pi): add pi coding agent via cachix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -102,13 +102,64 @@
         "type": "github"
       }
     },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1773646010,
+        "narHash": "sha256-iYrs97hS7p5u4lQzuNWzuALGIOdkPXvjz7bviiBjUu8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5b2c2d84341b2afb5647081c1386a80d7a8d8605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pi": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_3",
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1780013802,
+        "narHash": "sha256-C07d2jJozCZWJrC8cRohsMqWN9ZSl0Fn4M7tqfe21TI=",
+        "owner": "lukasl-dev",
+        "repo": "pi.nix",
+        "rev": "bbb7cc006676d6812283f41b8807a588c3d1554d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lukasl-dev",
+        "repo": "pi.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "claude-code": "claude-code",
         "fish-plugin-fzf": "fish-plugin-fzf",
         "fish-plugin-z": "fish-plugin-z",
         "home-manager": "home-manager",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_2",
+        "pi": "pi"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,11 @@
     claude-code = {
       url = "github:ryoppippi/claude-code-overlay";
     };
+
+    # Pi coding agent (native binary with Cachix)
+    pi = {
+      url = "github:lukasl-dev/pi.nix";
+    };
   };
 
   outputs = { self, nixpkgs, home-manager, ... }@inputs:
@@ -40,6 +45,7 @@
         config.allowUnfree = true;
         overlays = [
           inputs.claude-code.overlays.default
+          inputs.pi.overlays.default
         ];
       });
     in

--- a/home.nix
+++ b/home.nix
@@ -58,6 +58,7 @@ in
     gh-dash    # TUI dashboard for GitHub PRs and issues
     ghq        # Git repository manager
     claude-code # Claude AI coding assistant (native binary via ryoppippi/claude-code-overlay)
+    pi-coding-agent # Pi coding agent (native binary via lukasl-dev/pi.nix; Codex/Claude/Copilot subscription login)
 
     # Containers
     podman     # Daemonless container engine (docker-compatible CLI)
@@ -96,8 +97,8 @@ in
       experimental-features = nix-command flakes
       warn-dirty = false
       accept-flake-config = true
-      extra-substituters = https://ryoppippi.cachix.org
-      extra-trusted-public-keys = ryoppippi.cachix.org-1:b2LbtWNvJeL/qb1B6TYOMK+apaCps4SCbzlPRfSQIms=
+      extra-substituters = https://ryoppippi.cachix.org https://pi.cachix.org
+      extra-trusted-public-keys = ryoppippi.cachix.org-1:b2LbtWNvJeL/qb1B6TYOMK+apaCps4SCbzlPRfSQIms= pi.cachix.org-1:lGeoGJaZ5ZDabuRzkcD5EBTNnDM4HJ1vqeOxlWk1Flk=
       !include ${config.home.homeDirectory}/.config/nix/nix.local.conf
     '';
   };


### PR DESCRIPTION
## What

Adds the [pi coding agent](https://pi.dev) installed as a **Nix package via the [`lukasl-dev/pi.nix`](https://github.com/lukasl-dev/pi.nix) flake** (the `pi.cachix.org` binary cache) — **not** the npm package. Wired in to mirror the existing `claude-code` setup, so `pi` behaves just like `claude`.

## Changes

- **`flake.nix`**: add the `pi` flake input (`github:lukasl-dev/pi.nix`) and apply its `overlays.default` alongside the claude-code overlay.
- **`home.nix`**: add `pi-coding-agent` to `home.packages`, and append `pi.cachix.org` (substituter + public key) to the managed `nix.conf`.
- **`flake.lock`**: lock the new `pi` input (+ transitive `pi/nixpkgs`, `pi/systems`).

## Codex / subscription support

pi has built-in subscription logins for **ChatGPT Plus/Pro (Codex)**, Claude Pro/Max, and GitHub Copilot. No provider config is needed in Nix — authenticate at runtime via `pi` → `/login` (tokens stored in `~/.pi/agent/auth.json`, auto-refreshed), exactly like logging into Claude Code.

## Verification

- `nix flake check` ✅ passes
- `home-manager switch --flake .#nixos@wsl` ✅ applied
- `pi --version` → `0.77.0`, installed at `~/.nix-profile/bin/pi` next to `claude` ✅

## Note (binary cache effectiveness)

On this host `trusted-users = root`, so user-specified cachix substituters (both `ryoppippi.cachix.org` and the new `pi.cachix.org`) are ignored at build time — pi is fetched/assembled locally via its fixed-output derivation rather than pulled as a prebuilt closure. This matches existing claude-code behavior. Making the cache truly effective would require adding these substituters at the **system** level (`nix.settings.substituters` + `trusted-public-keys`) or adding the user to `trusted-users` — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
