### PR TITLE
:arrow_up: chore(flake): update inputs and tidy claude/settings.json

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -110,10 +110,13 @@
     "learning-output-style@claude-plugins-official": true,
     "context7@claude-plugins-official": true
   },
+  "effortLevel": "xhigh",
   "showThinkingSummaries": true,
   "theme": "light",
   "editorMode": "vim",
   "skipAutoPermissionPrompt": true,
-  "additionalDirectories": ["~/wkspace/**", "~/.config/dotfiles/**"],
-  "effortLevel": "xhigh"
+  "additionalDirectories": [
+    "~/wkspace/**",
+    "~/.config/dotfiles/**"
+  ]
 }

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1779569414,
-        "narHash": "sha256-6Tgl9dIDkHa7KX7MID0hkVEaryR8OMWrcV43bdWEOmw=",
+        "lastModified": 1780030383,
+        "narHash": "sha256-vininGIqTM3wYHDejG3c/cfHgVQch4T8e2heXHP5emA=",
         "owner": "ryoppippi",
         "repo": "claude-code-overlay",
-        "rev": "6b5a0e9bee689f0f21ad9f19c19a359ebe0593e0",
+        "rev": "02fce910bfd96f2dc9e2df734bd53fbe198b2eb0",
         "type": "github"
       },
       "original": {
@@ -57,11 +57,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779726696,
-        "narHash": "sha256-/p37CB5n6Wpw250b0Lq0CYwNq2D8uGKzDoBulyLcQqA=",
+        "lastModified": 1779969295,
+        "narHash": "sha256-HwIJ3tOcwSMiV75L7KqJXciXR9UfT+d7rwOZMX7cTnA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1a95e2efb477959b70b4a14c51035975c0481df6",
+        "rev": "61e2c9659324181e0f0ed911958c536333b1d4f6",
         "type": "github"
       },
       "original": {
@@ -72,11 +72,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774106199,
-        "narHash": "sha256-US5Tda2sKmjrg2lNHQL3jRQ6p96cgfWh3J1QBliQ8Ws=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6c9a78c09ff4d6c21d0319114873508a6ec01655",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Two small follow-ups to the post-pi-merge state, bundled into one chore PR.

### `flake.lock` — input bumps

Routine refresh of three upstream inputs:

| Input | New rev |
|---|---|
| `claude-code-overlay` | `02fce910bfd96f2dc9e2df734bd53fbe198b2eb0` |
| `home-manager` | `61e2c9659324181e0f0ed911958c536333b1d4f6` |
| `nixpkgs` (nixos-unstable) | `64c08a7ca051951c8eae34e3e3cb1e202fe36786` |

`pi`, `fish-plugin-z`, and `fish-plugin-fzf` are unchanged.

### `claude/settings.json` — tidy

- Hoist `"effortLevel": "xhigh"` from the bottom of the file to just under the plugins block, where most other top-level scalars live.
- Reformat `additionalDirectories` from a one-line array to multi-line (matches the style of the rest of the file). No content change to the array itself.

## Verification

- `nix flake check` ✅ passes (all 6 inputs evaluate cleanly).
- `home-manager switch --flake .#nixos@wsl` ✅ applied; new generation active with bumped revs.
- `claude` and `pi` both still on PATH from the new generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
