### PR TITLE
:sparkles: feat(claude): nudge toward ast-grep for structural code search

### DIFF
--- a/claude/ast-grep-nudge-hook.sh
+++ b/claude/ast-grep-nudge-hook.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# PreToolUse hook (matcher: Grep): nudge toward ast-grep for STRUCTURAL code
+# queries. Non-blocking — the Grep always runs; this only injects a one-line
+# reminder via additionalContext that `ast-grep`/`sg` matches syntax (AST)
+# while Grep matches text. ast-grep here parses nix, lua, sh, json, yaml, css;
+# Grep stays the right tool for plain text (strings, comments, filenames, md).
+
+set -u
+
+# Drain stdin (the PreToolUse payload) so the writer never sees EPIPE. The
+# nudge is static, so we don't inspect the search pattern.
+cat >/dev/null
+
+msg='Tip: for STRUCTURAL code queries (call sites, def/usage shapes, AST patterns) in nix/lua/sh/json/yaml/css, prefer ast-grep — `ast-grep -p <pattern> -l <lang>` (alias `sg`) matches syntax, not text. For plain-text matches (strings, comments, filenames, markdown), Grep is correct; carry on.'
+
+jq -n --arg msg "$msg" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    additionalContext: $msg
+  },
+  suppressOutput: true
+}'

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -63,6 +63,17 @@
     "defaultMode": "auto"
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/ast-grep-nudge-hook.sh"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "matcher": "",

--- a/modules/claude-code.nix
+++ b/modules/claude-code.nix
@@ -11,6 +11,7 @@ in
   home.file.".claude/stop-hook-git-check.sh".source = mkSymlink "${dotfilesClaudePath}/stop-hook-git-check.sh";
   home.file.".claude/stop-phrase-guard.sh".source = mkSymlink "${dotfilesClaudePath}/stop-phrase-guard.sh";
   home.file.".claude/wsl-clipboard-image-hook.sh".source = mkSymlink "${dotfilesClaudePath}/wsl-clipboard-image-hook.sh";
+  home.file.".claude/ast-grep-nudge-hook.sh".source = mkSymlink "${dotfilesClaudePath}/ast-grep-nudge-hook.sh";
 
   # Run marketplace plugin setup after build
   home.activation.setupClaudeCode = lib.hm.dag.entryAfter [ "writeBoundary" ] ''


### PR DESCRIPTION
## What

Adds a **non-blocking** `PreToolUse` hook (matcher: `Grep`) that nudges toward `ast-grep`/`sg` for **structural** code queries (call sites, def/usage shapes, AST patterns), while keeping ripgrep/`Grep` as the right tool for plain-text search. The `Grep` call always runs — the hook only injects a one-line reminder via `additionalContext`.

## Why

`ast-grep` is already allow-listed but underused for structural navigation. ast-grep 0.42.1 parses every code language in this repo (nix, lua, sh, json, yaml, css); markdown stays text-search territory. A reminder beats a hard block, which would wrongly penalize the many searches that are legitimately plain text.

## Changes

- `claude/ast-grep-nudge-hook.sh` — reads the PreToolUse payload, emits `hookSpecificOutput.additionalContext` (stdout suppressed). Follows the existing hook-script idiom (`wsl-clipboard-image-hook.sh`).
- `modules/claude-code.nix` — `home.file` symlink so the script lands in `~/.claude/`.
- `claude/settings.json` — registers the hook under `hooks.PreToolUse`.

## Verification

- Script emits valid PreToolUse JSON — pipe-tested with a synthetic `Grep` payload and via the live `~/.claude/` symlink (exit 0).
- `settings.json` parses; hook registered under `PreToolUse`/`Grep`; existing `Stop`/`UserPromptSubmit` hooks intact.
- `home-manager switch --flake .#nixos@wsl` succeeds; `~/.claude/ast-grep-nudge-hook.sh` symlink created and resolves to the repo file.
- Takes effect in a **new** session (settings.json hooks load at session start).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
