### PR TITLE
:wrench: chore(pi): configure codex 1m context

### DIFF
--- a/modules/pi.nix
+++ b/modules/pi.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 
 {
   # Pi coding-agent compatibility defaults for users migrating from Claude Code.
@@ -22,17 +22,80 @@
   home.file.".pi/agent/themes/claude-code.json".source = ../pi/claude-code-theme.json;
 
   # Keep existing pi settings/auth intact, but select the Claude Code-like theme.
-  home.activation.setPiClaudeCodeTheme = ''
+  home.activation.setPiClaudeCodeTheme = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     settings="$HOME/.pi/agent/settings.json"
-    mkdir -p "$HOME/.pi/agent"
 
-    if [ -s "$settings" ]; then
-      ${pkgs.jq}/bin/jq '.theme = "claude-code" | .enableSkillCommands = true' "$settings" > "$settings.tmp"
+    if [ -n "''${DRY_RUN:-}" ]; then
+      echo "Would update $settings with the Claude Code-like pi theme"
     else
-      ${pkgs.jq}/bin/jq -n '{ theme: "claude-code", enableSkillCommands: true }' > "$settings.tmp"
-    fi
+      mkdir -p "$HOME/.pi/agent"
 
-    mv "$settings.tmp" "$settings"
+      if [ -s "$settings" ]; then
+        ${pkgs.jq}/bin/jq '.theme = "claude-code" | .enableSkillCommands = true' "$settings" > "$settings.tmp"
+      else
+        ${pkgs.jq}/bin/jq -n '{ theme: "claude-code", enableSkillCommands: true }' > "$settings.tmp"
+      fi
+
+      mv "$settings.tmp" "$settings"
+    fi
+  '';
+
+  # Pi reads context-window metadata from models.json. The OpenAI Codex
+  # GPT-5.4/GPT-5.5 models default to 272K in pi's bundled metadata, but can use
+  # the experimental 1M-token context window. Merge the override so any existing
+  # custom providers or model settings remain intact.
+  home.activation.setPiCodexContextWindow = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        models="$HOME/.pi/agent/models.json"
+
+        if [ -n "''${DRY_RUN:-}" ]; then
+          echo "Would update $models with 1M OpenAI Codex context-window overrides"
+        else
+          mkdir -p "$HOME/.pi/agent"
+
+          MODELS_PATH="$models" ${pkgs.nodejs}/bin/node --input-type=module <<'NODE'
+    import { existsSync, readFileSync, writeFileSync } from "node:fs";
+
+    const modelsPath = process.env.MODELS_PATH;
+
+    function stripJsonComments(input) {
+      return input
+        .replace(/"(?:\\.|[^"\\])*"|\/\/[^\n]*/g, (match) => match[0] === '"' ? match : "")
+        .replace(/"(?:\\.|[^"\\])*"|,(\s*[}\]])/g, (match, tail) => tail ?? (match[0] === '"' ? match : ""));
+    }
+
+    let config = {};
+    if (existsSync(modelsPath) && readFileSync(modelsPath, "utf8").trim().length > 0) {
+      config = JSON.parse(stripJsonComments(readFileSync(modelsPath, "utf8")));
+    }
+
+    if (config === null || typeof config !== "object" || Array.isArray(config)) {
+      config = {};
+    }
+    if (config.providers === null || typeof config.providers !== "object" || Array.isArray(config.providers)) {
+      config.providers = {};
+    }
+    if (config.providers["openai-codex"] === null || typeof config.providers["openai-codex"] !== "object" || Array.isArray(config.providers["openai-codex"])) {
+      config.providers["openai-codex"] = {};
+    }
+
+    const codex = config.providers["openai-codex"];
+    if (codex.modelOverrides === null || typeof codex.modelOverrides !== "object" || Array.isArray(codex.modelOverrides)) {
+      codex.modelOverrides = {};
+    }
+
+    for (const modelId of ["gpt-5.4", "gpt-5.5"]) {
+      const current = codex.modelOverrides[modelId];
+      codex.modelOverrides[modelId] = {
+        ...(current && typeof current === "object" && !Array.isArray(current) ? current : {}),
+        contextWindow: 1000000,
+      };
+    }
+
+    writeFileSync(modelsPath + ".tmp", JSON.stringify(config, null, 2) + "\n");
+    NODE
+
+          mv "$models.tmp" "$models"
+        fi
   '';
 
   # Extra insert-mode navigation that mirrors pi's documented Vim example.


### PR DESCRIPTION
## Summary
- Merge Pi models.json overrides for OpenAI Codex gpt-5.4 and gpt-5.5 to use a 1M context window.
- Preserve existing Pi model/provider settings, including JSON-with-comments/trailing-comma files.
- Run Pi activation scripts after Home Manager writeBoundary and skip mutations during dry runs.

## Test Plan
- home-manager switch --flake .#nixos@wsl
- nix flake check
- pi --list-models gpt-5.5
- pi --list-models gpt-5.4