### PR TITLE
:sparkles: feat(pi): add session goal command

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -138,6 +138,23 @@
         };
       };
 
+      # Test checks
+      checks = forAllSystems (system:
+        let pkgs = nixpkgsFor.${system};
+        in {
+          pi-goal-tests = pkgs.runCommand "pi-goal-tests"
+            {
+              src = self;
+              nativeBuildInputs = [ pkgs.nodejs ];
+            } ''
+            cp -R "$src" source
+            chmod -R u+w source
+            cd source
+            node --test pi/goal/core.test.ts pi/goal/index.test.ts
+            touch "$out"
+          '';
+        });
+
       # Development shell for testing
       devShells = forAllSystems (system:
         let pkgs = nixpkgsFor.${system};

--- a/modules/pi.nix
+++ b/modules/pi.nix
@@ -9,6 +9,8 @@
     [ "${pkgs.pi-coding-agent}/lib/node_modules" ]
     (builtins.readFile ../pi/claude-vim.ts);
   home.file.".pi/agent/extensions/agent-compat.ts".source = ../pi/agent-compat.ts;
+  home.file.".pi/agent/extensions/goal/index.ts".source = ../pi/goal/index.ts;
+  home.file.".pi/agent/extensions/goal/core.ts".source = ../pi/goal/core.ts;
   home.file.".pi/agent/extensions/subagents/index.ts".text = builtins.replaceStrings
     [ "@PI_NODE_MODULES@" "@PI_SUBAGENTS_CORE@" ]
     [ "${pkgs.pi-coding-agent}/lib/node_modules" "${../pi/subagents/core.ts}" ]

--- a/pi/goal/core.test.ts
+++ b/pi/goal/core.test.ts
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  GOAL_CUSTOM_ENTRY_TYPE,
+  buildGoalPromptSection,
+  parseGoalCommand,
+  reconstructGoalFromEntries,
+  truncateGoalForStatus,
+} from "./core.ts";
+
+test("parses show, set, and clear goal commands", () => {
+  assert.deepEqual(parseGoalCommand(""), { action: "show" });
+  assert.deepEqual(parseGoalCommand("   "), { action: "show" });
+  assert.deepEqual(parseGoalCommand("ship the pi goal command"), {
+    action: "set",
+    goal: "ship the pi goal command",
+  });
+  assert.deepEqual(parseGoalCommand(" clear "), { action: "clear" });
+  assert.deepEqual(parseGoalCommand("reset"), { action: "clear" });
+  assert.deepEqual(parseGoalCommand("clear the blockers"), {
+    action: "set",
+    goal: "clear the blockers",
+  });
+});
+
+test("rejects blank goals after normalization", () => {
+  assert.deepEqual(parseGoalCommand("\n\t"), { action: "show" });
+});
+
+test("reconstructs the latest goal from session branch entries", () => {
+  const entries = [
+    { type: "custom", customType: GOAL_CUSTOM_ENTRY_TYPE, data: { action: "set", goal: "first" } },
+    { type: "message", message: { role: "user" } },
+    { type: "custom", customType: GOAL_CUSTOM_ENTRY_TYPE, data: { action: "set", goal: "second" } },
+  ];
+
+  assert.equal(reconstructGoalFromEntries(entries), "second");
+});
+
+test("reconstructs cleared goal from session branch entries", () => {
+  const entries = [
+    { type: "custom", customType: GOAL_CUSTOM_ENTRY_TYPE, data: { action: "set", goal: "first" } },
+    { type: "custom", customType: GOAL_CUSTOM_ENTRY_TYPE, data: { action: "clear" } },
+  ];
+
+  assert.equal(reconstructGoalFromEntries(entries), undefined);
+});
+
+test("ignores malformed goal entries", () => {
+  const entries = [
+    { type: "custom", customType: GOAL_CUSTOM_ENTRY_TYPE, data: { action: "set", goal: "valid" } },
+    { type: "custom", customType: GOAL_CUSTOM_ENTRY_TYPE, data: { action: "set", goal: "" } },
+    { type: "custom", customType: GOAL_CUSTOM_ENTRY_TYPE, data: { action: "unknown", goal: "bad" } },
+  ];
+
+  assert.equal(reconstructGoalFromEntries(entries), "valid");
+});
+
+test("truncates goal text for compact status display", () => {
+  assert.equal(truncateGoalForStatus("short goal", 20), "short goal");
+  assert.equal(truncateGoalForStatus("12345678901234567890", 20), "12345678901234567890");
+  assert.equal(truncateGoalForStatus("123456789012345678901", 20), "12345678901234567...");
+});
+
+test("builds a concise current-goal prompt section", () => {
+  assert.equal(buildGoalPromptSection(undefined), undefined);
+  assert.equal(
+    buildGoalPromptSection("ship the pi goal command"),
+    "\n\nCurrent session goal:\nship the pi goal command\n\nUse this goal to stay oriented. If the user's latest request conflicts with it, follow the latest user request and mention the mismatch.",
+  );
+});
+
+test("limits goal text injected into the prompt", () => {
+  assert.equal(
+    buildGoalPromptSection("123456789012345678901", 20),
+    "\n\nCurrent session goal:\n12345678901234567...\n\nUse this goal to stay oriented. If the user's latest request conflicts with it, follow the latest user request and mention the mismatch.",
+  );
+});

--- a/pi/goal/core.ts
+++ b/pi/goal/core.ts
@@ -1,0 +1,59 @@
+export const GOAL_CUSTOM_ENTRY_TYPE = "goal";
+export const GOAL_PROMPT_MAX_LENGTH = 1000;
+
+export type GoalCommand =
+  | { action: "show" }
+  | { action: "clear" }
+  | { action: "set"; goal: string };
+
+export type GoalEntryData =
+  | { action: "set"; goal: string; timestamp?: number }
+  | { action: "clear"; timestamp?: number };
+
+export function parseGoalCommand(args: string): GoalCommand {
+  const normalized = args.trim().replace(/\s+/g, " ");
+
+  if (!normalized) return { action: "show" };
+  if (normalized === "clear" || normalized === "reset") return { action: "clear" };
+
+  return { action: "set", goal: normalized };
+}
+
+export function reconstructGoalFromEntries(entries: Array<Record<string, any>>): string | undefined {
+  let goal: string | undefined;
+
+  for (const entry of entries) {
+    if (entry?.type !== "custom" || entry.customType !== GOAL_CUSTOM_ENTRY_TYPE) continue;
+
+    const data = entry.data as GoalEntryData | undefined;
+    if (data?.action === "clear") {
+      goal = undefined;
+      continue;
+    }
+
+    if (data?.action === "set" && typeof data.goal === "string" && data.goal.trim()) {
+      goal = data.goal.trim();
+    }
+  }
+
+  return goal;
+}
+
+export function truncateGoalForStatus(goal: string, maxLength = 48): string {
+  if (goal.length <= maxLength) return goal;
+  if (maxLength <= 3) return ".".repeat(Math.max(0, maxLength));
+  return `${goal.slice(0, maxLength - 3)}...`;
+}
+
+export function buildGoalPromptSection(goal: string | undefined, maxLength = GOAL_PROMPT_MAX_LENGTH): string | undefined {
+  if (!goal?.trim()) return undefined;
+
+  return [
+    "",
+    "",
+    "Current session goal:",
+    truncateGoalForStatus(goal.trim(), maxLength),
+    "",
+    "Use this goal to stay oriented. If the user's latest request conflicts with it, follow the latest user request and mention the mismatch.",
+  ].join("\n");
+}

--- a/pi/goal/index.test.ts
+++ b/pi/goal/index.test.ts
@@ -1,0 +1,109 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import goalExtension from "./index.ts";
+import { GOAL_CUSTOM_ENTRY_TYPE } from "./core.ts";
+
+function createHarness(branch: Array<Record<string, any>> = []) {
+  const handlers = new Map<string, Array<Function>>();
+  const commands = new Map<string, any>();
+  const appended: Array<{ customType: string; data: Record<string, any> }> = [];
+  const notifications: Array<{ message: string; level: string }> = [];
+  const statuses = new Map<string, string | undefined>();
+
+  const pi = {
+    on(name: string, handler: Function) {
+      handlers.set(name, [...(handlers.get(name) ?? []), handler]);
+    },
+    registerCommand(name: string, definition: any) {
+      commands.set(name, definition);
+    },
+    appendEntry(customType: string, data: Record<string, any>) {
+      appended.push({ customType, data });
+    },
+  };
+
+  const ctx = {
+    hasUI: true,
+    sessionManager: {
+      getBranch: () => branch,
+    },
+    ui: {
+      setStatus(key: string, value: string | undefined) {
+        statuses.set(key, value);
+      },
+      notify(message: string, level: string) {
+        notifications.push({ message, level });
+      },
+    },
+  };
+
+  goalExtension(pi as any);
+
+  return { appended, commands, ctx, handlers, notifications, statuses };
+}
+
+test("restores session goal, updates status, and injects prompt context", async () => {
+  const { ctx, handlers, statuses } = createHarness([
+    { type: "custom", customType: GOAL_CUSTOM_ENTRY_TYPE, data: { action: "set", goal: "ship goal command" } },
+  ]);
+
+  await handlers.get("session_start")![0]!({}, ctx);
+  assert.equal(statuses.get("goal"), "goal: ship goal command");
+
+  const result = await handlers.get("before_agent_start")![0]!({ systemPrompt: "base" }, ctx);
+  assert.equal(
+    result.systemPrompt,
+    "base\n\nCurrent session goal:\nship goal command\n\nUse this goal to stay oriented. If the user's latest request conflicts with it, follow the latest user request and mention the mismatch.",
+  );
+});
+
+test("refreshes goal status after tree navigation", async () => {
+  const branch = [
+    { type: "custom", customType: GOAL_CUSTOM_ENTRY_TYPE, data: { action: "set", goal: "old branch goal" } },
+  ];
+  const { ctx, handlers, statuses } = createHarness(branch);
+
+  await handlers.get("session_start")![0]!({}, ctx);
+  assert.equal(statuses.get("goal"), "goal: old branch goal");
+
+  branch.push({ type: "custom", customType: GOAL_CUSTOM_ENTRY_TYPE, data: { action: "set", goal: "new branch goal" } });
+  await handlers.get("session_tree")![0]!({}, ctx);
+  assert.equal(statuses.get("goal"), "goal: new branch goal");
+});
+
+test("goal command shows, sets, and clears current session goal", async () => {
+  const { appended, commands, ctx, handlers, notifications, statuses } = createHarness();
+  const goal = commands.get("goal");
+
+  await handlers.get("session_start")![0]!({}, ctx);
+  await goal.handler("", ctx);
+  assert.deepEqual(notifications.at(-1), { message: "No session goal set", level: "info" });
+
+  await goal.handler("finish the tests", ctx);
+  assert.equal(statuses.get("goal"), "goal: finish the tests");
+  assert.equal(appended.at(-1)?.customType, GOAL_CUSTOM_ENTRY_TYPE);
+  assert.deepEqual(
+    { action: appended.at(-1)?.data.action, goal: appended.at(-1)?.data.goal },
+    { action: "set", goal: "finish the tests" },
+  );
+  assert.deepEqual(notifications.at(-1), { message: "Session goal set: finish the tests", level: "info" });
+
+  await goal.handler("", ctx);
+  assert.deepEqual(notifications.at(-1), { message: "Current goal: finish the tests", level: "info" });
+
+  await goal.handler("clear", ctx);
+  assert.equal(statuses.get("goal"), undefined);
+  assert.equal(appended.at(-1)?.customType, GOAL_CUSTOM_ENTRY_TYPE);
+  assert.deepEqual({ action: appended.at(-1)?.data.action }, { action: "clear" });
+  assert.deepEqual(notifications.at(-1), { message: "Session goal cleared", level: "info" });
+});
+
+test("does not inject prompt context when no goal is set", async () => {
+  const { ctx, handlers } = createHarness();
+
+  await handlers.get("session_start")![0]!({}, ctx);
+  const result = await handlers.get("before_agent_start")![0]!({ systemPrompt: "base" }, ctx);
+
+  assert.equal(result, undefined);
+});

--- a/pi/goal/index.ts
+++ b/pi/goal/index.ts
@@ -1,0 +1,84 @@
+/**
+ * Session-scoped goal command for pi.
+ *
+ * Loaded globally by Home Manager at ~/.pi/agent/extensions/goal/index.ts.
+ */
+
+// @ts-nocheck
+import {
+  GOAL_CUSTOM_ENTRY_TYPE,
+  buildGoalPromptSection,
+  parseGoalCommand,
+  reconstructGoalFromEntries,
+  truncateGoalForStatus,
+} from "./core.ts";
+
+const STATUS_KEY = "goal";
+
+export default function (pi) {
+  let currentGoal;
+
+  function setStatus(ctx) {
+    if (!ctx.hasUI) return;
+
+    if (currentGoal) {
+      ctx.ui.setStatus(STATUS_KEY, `goal: ${truncateGoalForStatus(currentGoal)}`);
+    } else {
+      ctx.ui.setStatus(STATUS_KEY, undefined);
+    }
+  }
+
+  function refreshGoal(ctx) {
+    currentGoal = reconstructGoalFromEntries(ctx.sessionManager.getBranch());
+    setStatus(ctx);
+  }
+
+  pi.on("session_start", async (_event, ctx) => {
+    refreshGoal(ctx);
+  });
+
+  pi.on("session_tree", async (_event, ctx) => {
+    refreshGoal(ctx);
+  });
+
+  pi.on("before_agent_start", async (event) => {
+    const section = buildGoalPromptSection(currentGoal);
+    if (!section) return;
+
+    return { systemPrompt: event.systemPrompt + section };
+  });
+
+  pi.registerCommand("goal", {
+    description: "Set, show, or clear the current session goal",
+    getArgumentCompletions: (prefix) => {
+      const commands = ["clear", "reset"];
+      const filtered = commands.filter((command) => command.startsWith(prefix));
+      return filtered.length > 0 ? filtered.map((command) => ({ value: command, label: command })) : null;
+    },
+    handler: async (args, ctx) => {
+      const command = parseGoalCommand(args);
+
+      if (command.action === "show") {
+        ctx.ui.notify(currentGoal ? `Current goal: ${currentGoal}` : "No session goal set", "info");
+        return;
+      }
+
+      if (command.action === "clear") {
+        currentGoal = undefined;
+        pi.appendEntry(GOAL_CUSTOM_ENTRY_TYPE, { action: "clear", timestamp: Date.now() });
+        setStatus(ctx);
+        ctx.ui.notify("Session goal cleared", "info");
+        return;
+      }
+
+      currentGoal = command.goal;
+      pi.appendEntry(GOAL_CUSTOM_ENTRY_TYPE, {
+        action: "set",
+        goal: currentGoal,
+        timestamp: Date.now(),
+      });
+      setStatus(ctx);
+      ctx.ui.notify(`Session goal set: ${currentGoal}`, "info");
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- add a session-scoped pi `/goal` extension with set/show/clear behavior
- restore goal state from session branch entries and inject bounded goal context into future turns
- wire goal helper tests into `nix flake check`

## Test Plan
- `node --test pi/goal/core.test.ts pi/goal/index.test.ts`
- `nix flake check`
- `home-manager switch --flake '.#nixos@wsl'`\n- `PI_OFFLINE=1 pi --no-session -p "/goal ship test"`