### PR TITLE
:sparkles: feat(pi): show subagent progress status

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -153,6 +153,18 @@
             node --test pi/goal/core.test.ts pi/goal/index.test.ts
             touch "$out"
           '';
+
+          pi-subagents-tests = pkgs.runCommand "pi-subagents-tests"
+            {
+              src = self;
+              nativeBuildInputs = [ pkgs.nodejs ];
+            } ''
+            cp -R "$src" source
+            chmod -R u+w source
+            cd source
+            node --test pi/subagents/core.test.ts
+            touch "$out"
+          '';
         });
 
       # Development shell for testing

--- a/pi/subagents/core.test.ts
+++ b/pi/subagents/core.test.ts
@@ -6,8 +6,11 @@ import {
   buildSubagentPrompt,
   extractFinalAssistantText,
   formatCombinedReport,
+  formatSubagentProgressStatus,
+  formatSubagentProgressUpdate,
   normalizeSubagentInput,
   supportsNativeWebSearch,
+  type SubagentProgressEntry,
 } from "./core.ts";
 
 const anthropicModel = {
@@ -142,6 +145,37 @@ test("extracts the final assistant text block from a child session", () => {
   ]);
 
   assert.equal(text, "final\nanswer");
+});
+
+test("formats subagent progress status with running purpose labels", () => {
+  const entries: SubagentProgressEntry[] = [
+    { id: "code-1", domain: "code", task: "Map the auth flow.", state: "ok" },
+    { id: "test-2", domain: "test", task: "Find relevant test commands.", state: "running" },
+    { id: "docs-3", domain: "docs", task: "Check user-facing docs.", state: "queued" },
+    { id: "security-4", domain: "security", task: "Review token handling.", state: "error" },
+  ];
+
+  assert.equal(
+    formatSubagentProgressStatus(entries, 200),
+    "subagents: 2/4 done, 1 running, 1 queued, 1 failed — test-2: Find relevant test commands.",
+  );
+});
+
+test("formats subagent progress updates with every task status", () => {
+  const entries: SubagentProgressEntry[] = [
+    { id: "code-1", domain: "code", task: "Map the auth flow.", state: "ok" },
+    { id: "test-2", domain: "test", task: "Find relevant test commands.", state: "running" },
+    { id: "docs-3", domain: "docs", task: "Check user-facing docs.", state: "queued" },
+    { id: "security-4", domain: "security", task: "Review token handling.", state: "error" },
+  ];
+
+  const update = formatSubagentProgressUpdate(entries);
+
+  assert.match(update, /Subagents: 2\/4 done, 1 running, 1 queued, 1 failed/);
+  assert.match(update, /✓ code-1 \(code\) — Map the auth flow\./);
+  assert.match(update, /⏳ test-2 \(test\) — Find relevant test commands\./);
+  assert.match(update, /○ docs-3 \(docs\) — Check user-facing docs\./);
+  assert.match(update, /✗ security-4 \(security\) — Review token handling\./);
 });
 
 test("formats consolidated reports with successes and per-agent failures", () => {

--- a/pi/subagents/core.ts
+++ b/pi/subagents/core.ts
@@ -54,6 +54,15 @@ export interface SubagentRunResult {
   error?: string;
 }
 
+export type SubagentProgressState = "queued" | "running" | "ok" | "error";
+
+export interface SubagentProgressEntry {
+  id: string;
+  domain: string;
+  task: string;
+  state: SubagentProgressState;
+}
+
 const CONTEXT_MODES = new Set<SubagentContextMode>(["none", "brief", "recent", "files"]);
 
 const DOMAIN_INSTRUCTIONS: Record<string, string> = {
@@ -212,6 +221,74 @@ export function formatCombinedReport(results: SubagentRunResult[]): string {
   }
 
   return lines.join("\n").trimEnd() + "\n";
+}
+
+export function formatSubagentProgressStatus(entries: SubagentProgressEntry[], maxLength = 120): string {
+  const summary = formatSubagentProgressSummary(entries);
+  const running = entries.filter((entry) => entry.state === "running");
+  const queued = entries.filter((entry) => entry.state === "queued");
+  const labelEntries = running.length > 0 ? running : queued;
+  const labels = labelEntries.map(formatSubagentStatusLabel);
+  const labelSuffix = labels.length > 0 ? ` — ${labels.join("; ")}` : "";
+
+  return truncateSingleLine(`subagents: ${summary}${labelSuffix}`, maxLength);
+}
+
+export function formatSubagentProgressUpdate(entries: SubagentProgressEntry[]): string {
+  const lines = [`Subagents: ${formatSubagentProgressSummary(entries)}`, ""];
+
+  for (const entry of entries) {
+    lines.push(`${progressIcon(entry.state)} ${entry.id} (${entry.domain}) — ${compactSingleLine(entry.task)}`);
+  }
+
+  return lines.join("\n").trimEnd();
+}
+
+function formatSubagentProgressSummary(entries: SubagentProgressEntry[]): string {
+  const total = entries.length;
+  const running = entries.filter((entry) => entry.state === "running").length;
+  const queued = entries.filter((entry) => entry.state === "queued").length;
+  const failed = entries.filter((entry) => entry.state === "error").length;
+  const completed = entries.filter((entry) => entry.state === "ok" || entry.state === "error").length;
+  const parts = [`${completed}/${total} done`];
+
+  if (running > 0) parts.push(countStatus(running, "running"));
+  if (queued > 0) parts.push(countStatus(queued, "queued"));
+  if (failed > 0) parts.push(countStatus(failed, "failed"));
+
+  return parts.join(", ");
+}
+
+function formatSubagentStatusLabel(entry: SubagentProgressEntry): string {
+  const task = truncateSingleLine(compactSingleLine(entry.task), 44);
+  return `${entry.id}: ${task}`;
+}
+
+function progressIcon(state: SubagentProgressState): string {
+  switch (state) {
+    case "ok":
+      return "✓";
+    case "error":
+      return "✗";
+    case "running":
+      return "⏳";
+    case "queued":
+      return "○";
+  }
+}
+
+function compactSingleLine(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function truncateSingleLine(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  if (maxLength <= 1) return text.slice(0, Math.max(0, maxLength));
+  return `${text.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+function countStatus(count: number, label: string): string {
+  return `${count} ${label}`;
 }
 
 function normalizeTask(raw: RawSubagentTask, index: number): NormalizedSubagentTask {

--- a/pi/subagents/index.ts
+++ b/pi/subagents/index.ts
@@ -4,7 +4,8 @@
  *
  * This extension intentionally avoids tmux/pane orchestration. The parent pi
  * session gets one LLM-callable `subagent_many` tool that creates hidden,
- * in-memory child AgentSessions and returns only their final summaries.
+ * in-memory child AgentSessions, publishes compact progress to the TUI, and
+ * returns final summaries to the parent model.
  */
 
 import {
@@ -20,10 +21,13 @@ import {
   buildSubagentPrompt,
   extractFinalAssistantText,
   formatCombinedReport,
+  formatSubagentProgressStatus,
+  formatSubagentProgressUpdate,
   normalizeSubagentInput,
 } from "@PI_SUBAGENTS_CORE@";
 
 const READ_ONLY_TOOLS = ["read", "grep", "find", "ls"];
+const STATUS_KEY = "subagents";
 
 const taskSchema = Type.Object({
   id: Type.Optional(Type.String({ description: "Stable label for this subagent result, for example security-review." })),
@@ -75,32 +79,51 @@ export default function (pi) {
         };
       }
 
-      emitUpdate(onUpdate, `Starting ${normalized.tasks.length} subagent(s), max_parallel=${normalized.maxParallel}...`);
+      const progressEntries = normalized.tasks.map((task) => ({
+        id: task.id,
+        domain: task.domain,
+        task: task.task,
+        state: "queued",
+      }));
+
+      const setProgress = (index, state) => {
+        progressEntries[index] = { ...progressEntries[index], state };
+        emitProgressUpdate(onUpdate, progressEntries);
+        setSubagentStatus(ctx, progressEntries);
+      };
+
+      emitProgressUpdate(onUpdate, progressEntries);
+      setSubagentStatus(ctx, progressEntries);
 
       const startedAt = Date.now();
-      const results = await runWithConcurrency(normalized.tasks, normalized.maxParallel, async (task) => {
-        emitUpdate(onUpdate, `Running ${task.id} (${task.domain})...`);
-        const result = await runSubagent({ task, normalized, parentModel, parentPi: pi, parentCtx: ctx, signal });
-        emitUpdate(onUpdate, `Finished ${task.id}: ${result.status}.`);
-        return result;
-      });
 
-      const report = formatCombinedReport(results);
-      const details = {
-        toolCallId,
-        cwd: ctx.cwd,
-        model: `${parentModel.provider}/${parentModel.id}`,
-        durationMs: Date.now() - startedAt,
-        tasks: normalized.tasks,
-        results,
-      };
+      try {
+        const results = await runWithConcurrency(normalized.tasks, normalized.maxParallel, async (task, index) => {
+          setProgress(index, "running");
+          const result = await runSubagent({ task, normalized, parentModel, parentPi: pi, parentCtx: ctx, signal });
+          setProgress(index, result.status);
+          return result;
+        });
 
-      pi.appendEntry("subagent_many_report", details);
+        const report = formatCombinedReport(results);
+        const details = {
+          toolCallId,
+          cwd: ctx.cwd,
+          model: `${parentModel.provider}/${parentModel.id}`,
+          durationMs: Date.now() - startedAt,
+          tasks: normalized.tasks,
+          results,
+        };
 
-      return {
-        content: [{ type: "text", text: report }],
-        details,
-      };
+        pi.appendEntry("subagent_many_report", details);
+
+        return {
+          content: [{ type: "text", text: report }],
+          details,
+        };
+      } finally {
+        clearSubagentStatus(ctx);
+      }
     },
   });
 }
@@ -233,8 +256,18 @@ function truncateText(text, maxLength) {
   return `${text.slice(0, Math.max(0, maxLength - 14)).trimEnd()}\n[...truncated]`;
 }
 
-function emitUpdate(onUpdate, message) {
-  onUpdate?.({ content: [{ type: "text", text: message }] });
+function emitProgressUpdate(onUpdate, progressEntries) {
+  onUpdate?.({ content: [{ type: "text", text: formatSubagentProgressUpdate(progressEntries) }] });
+}
+
+function setSubagentStatus(ctx, progressEntries) {
+  if (!ctx.hasUI || !ctx.ui?.setStatus) return;
+  ctx.ui.setStatus(STATUS_KEY, formatSubagentProgressStatus(progressEntries));
+}
+
+function clearSubagentStatus(ctx) {
+  if (!ctx.hasUI || !ctx.ui?.setStatus) return;
+  ctx.ui.setStatus(STATUS_KEY, undefined);
 }
 
 function throwIfAborted(signal) {


### PR DESCRIPTION
## Summary
- Show live `subagent_many` progress in Pi's footer/status bar while hidden child agents run.
- Stream per-agent queued/running/success/error progress updates with task purpose text.
- Add subagent progress formatter tests and include them in flake checks.

## Test Plan
- [x] `node --test pi/goal/core.test.ts pi/goal/index.test.ts pi/subagents/core.test.ts`
- [x] `nixpkgs-fmt --check flake.nix`
- [x] `nix flake check`
- [x] `home-manager switch --flake .#nixos@wsl`

## Notes
- `home-manager switch --flake .` without an attribute fails in this repo because the flake defines named configurations; verified with `.#nixos@wsl`.
- Nix/Home Manager emitted existing warnings about untrusted substituters, Neovim defaults, ssh matchBlocks deprecation, Home Manager/Nixpkgs version mismatch, and `swww` rename.
