### PR TITLE
:zap: perf(neovim): optimize startup and preserve filer keymap

### DIFF
--- a/docs/superpowers/plans/2026-06-01-neovim-startup-performance.md
+++ b/docs/superpowers/plans/2026-06-01-neovim-startup-performance.md
@@ -1,0 +1,256 @@
+# Neovim Startup Performance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Neovim launch faster and keep `<leader>e` opening the file explorer in all buffers.
+
+**Architecture:** Keep the existing mini.nvim configuration, but split eager setup into idempotent lazy helpers. Keymaps call helper functions that initialize their feature on first use. LSP no longer shadows the file explorer keymap.
+
+**Tech Stack:** Neovim Lua config, mini.nvim, Lspsaga, Nix/Home Manager, Jujutsu.
+
+---
+
+### Task 1: Add keymap regression test
+
+**Files:**
+- Create: `nvim/tests/leader_e_minifiles.lua`
+
+- [ ] **Step 1: Write the failing test**
+
+```lua
+local plugins = require('config.plugins')
+
+assert(type(plugins.open_files) == 'function', 'config.plugins.open_files must exist')
+
+local function assert_open_files_loads_minifiles()
+  local ok, err = pcall(function()
+    plugins.open_files()
+  end)
+
+  assert(ok, 'config.plugins.open_files() errored: ' .. tostring(err))
+  assert(_G.MiniFiles and type(MiniFiles.open) == 'function', 'MiniFiles.open was not loaded')
+
+  if type(MiniFiles.close) == 'function' then
+    pcall(MiniFiles.close)
+  end
+end
+
+local function assert_map_invokes_file_explorer(lhs, expected_path, label)
+  local call = { seen = false, path = nil }
+  local original = plugins.open_files
+
+  plugins.open_files = function(path)
+    call.seen = true
+    call.path = path
+  end
+
+  local ok, err = pcall(function()
+    vim.api.nvim_feedkeys(vim.keycode(lhs), 'xt', false)
+  end)
+
+  plugins.open_files = original
+
+  assert(ok, label .. ': pressing ' .. lhs .. ' errored: ' .. tostring(err))
+  assert(call.seen, label .. ': ' .. lhs .. ' did not invoke config.plugins.open_files(); effective map = ' .. vim.inspect(vim.fn.maparg(lhs, 'n', false, true)))
+  assert(call.path == expected_path, label .. ': ' .. lhs .. ' passed path ' .. vim.inspect(call.path) .. ', expected ' .. vim.inspect(expected_path))
+end
+
+local function assert_file_explorer_maps(label)
+  assert_map_invokes_file_explorer('<leader>e', nil, label)
+  assert_map_invokes_file_explorer('<leader>E', vim.api.nvim_buf_get_name(0), label)
+end
+
+assert_open_files_loads_minifiles()
+assert_file_explorer_maps('startup')
+
+local buf = vim.api.nvim_create_buf(true, false)
+vim.api.nvim_set_current_buf(buf)
+vim.api.nvim_exec_autocmds('LspAttach', {
+  buffer = buf,
+  data = { client_id = 1 },
+})
+
+assert_file_explorer_maps('after LspAttach')
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd /home/nixos/wkspace/worktree/refactor/nvim-performance
+XDG_CONFIG_HOME="$PWD" nvim --headless +'luafile nvim/tests/leader_e_minifiles.lua' +'qa!'
+```
+
+Expected: FAIL with `config.plugins.open_files must exist` on the pre-implementation config.
+
+### Task 2: Split Neovim startup and lazy helpers
+
+**Files:**
+- Modify: `nvim/init.lua`
+- Modify: `nvim/lua/config/plugins.lua`
+- Modify: `nvim/lua/config/options.lua`
+- Modify: `modules/neovim.nix`
+
+- [ ] **Step 1: Implement lazy setup helpers**
+
+Add idempotent helpers in `nvim/lua/config/plugins.lua`:
+
+```lua
+local loaded = {}
+local function setup_once(name, callback)
+  if loaded[name] then return end
+  loaded[name] = true
+  callback()
+end
+```
+
+Expose helpers including `setup_core`, `setup_files`, `open_files`, `setup_editing`, `setup_completion`, `setup_picker`, `pick`, `pick_lsp`, `setup_git`, `setup_colorscheme`, `apply_colorscheme`, `setup_treesitter`, `setup_lspsaga`, `setup_lsp`, `setup_format`, and `setup_dap`.
+
+- [ ] **Step 2: Update startup orchestration**
+
+In `nvim/init.lua`, enable `vim.loader`, load options/keymaps/autocmds, initialize `mini.deps`, configure core plugins and colorscheme immediately, then register lazy keymaps/autocmds:
+
+```lua
+if vim.loader then
+  vim.loader.enable()
+end
+
+plugins.setup_core()
+plugins.setup_colorscheme()
+plugins.setup_treesitter()
+
+vim.keymap.set('n', '<leader>e', function() plugins.open_files() end, { desc = 'Open file explorer' })
+vim.keymap.set('n', '<leader>E', function() plugins.open_files(vim.api.nvim_buf_get_name(0)) end, { desc = 'Open file explorer at current file' })
+```
+
+Use `InsertEnter` for completion/snippets/editing, `BufReadPre`/`BufNewFile` for LSP/format/git, `vim.defer_fn` for which-key, and lazy debug keymaps for DAP. Add `mini-nvim` to `modules/neovim.nix` so Nix-managed Neovim does not need a network bootstrap for mini.nvim, and mark heavy plugins optional so helpers load them with `:packadd` on demand.
+
+- [ ] **Step 3: Remove global Treesitter folds**
+
+In `nvim/lua/config/options.lua`, change global folding defaults to manual and disabled:
+
+```lua
+vim.opt.foldmethod = 'manual'
+vim.opt.foldtext = ''
+vim.opt.foldlevel = 99
+vim.opt.foldlevelstart = 99
+vim.opt.foldenable = false
+```
+
+Configure Treesitter folds buffer-locally in `setup_treesitter()` after a parser starts.
+
+- [ ] **Step 4: Run regression test to verify it passes**
+
+Run:
+
+```bash
+cd /home/nixos/wkspace/worktree/refactor/nvim-performance
+XDG_CONFIG_HOME="$PWD" nvim --headless +'luafile nvim/tests/leader_e_minifiles.lua' +'qa!'
+```
+
+Expected: PASS with exit code 0 and no output.
+
+### Task 3: Move diagnostics key and update docs
+
+**Files:**
+- Modify: `nvim/lua/config/autocmds.lua`
+- Modify: `nvim/lua/config/keymaps.lua`
+- Modify: `nvim/KEYMAPS.md`
+- Modify: `nvim/README.md`
+
+- [ ] **Step 1: Move LSP diagnostic keymap**
+
+Change the LSP attach mapping from:
+
+```lua
+map('<leader>e', '<cmd>Lspsaga show_line_diagnostics<cr>', 'Line Diagnostics')
+```
+
+to:
+
+```lua
+map('<leader>cd', '<cmd>Lspsaga show_line_diagnostics<cr>', 'Line Diagnostics')
+```
+
+Change the global diagnostics list keymap from `<leader>q` to `<leader>cl` so `<leader>q` keeps its documented quit behavior.
+
+- [ ] **Step 2: Update keymap documentation**
+
+Document `<leader>cd` as line diagnostics, `<leader>cl` as the diagnostics list, and keep `<leader>e` documented only as the file explorer.
+
+- [ ] **Step 3: Run regression test again**
+
+Run:
+
+```bash
+cd /home/nixos/wkspace/worktree/refactor/nvim-performance
+XDG_CONFIG_HOME="$PWD" nvim --headless +'luafile nvim/tests/leader_e_minifiles.lua' +'qa!'
+```
+
+Expected: PASS with exit code 0 and no output.
+
+### Task 4: Verify startup and flake
+
+**Files:**
+- Modify: `flake.nix`
+
+- [ ] **Step 1: Add Neovim config flake check**
+
+Add an x86_64-linux `nvim-config-tests` check in `flake.nix` that uses `self.homeConfigurations."nixos@wsl".config.programs.neovim.finalPackage` and runs:
+
+```bash
+nvim --headless +'luafile nvim/tests/leader_e_minifiles.lua' +'qa!'
+nvim --headless nvim/init.lua +'lua assert(vim.fn.exists(":LspServers") == 2, "LspServers command missing"); local cfg = vim.lsp.config.lua_ls; assert(cfg and type(cfg.cmd) == "table" and #cfg.cmd > 0, "lua_ls cmd missing"); assert(vim.fn.maparg("<leader>l", "n") == "", "<leader>l maps to missing Lazy command")' +'qa!'
+```
+
+- [ ] **Step 2: Run startup smoke test**
+
+Run:
+
+```bash
+cd /home/nixos/wkspace/worktree/refactor/nvim-performance
+XDG_CONFIG_HOME="$PWD" nvim --headless +qa
+```
+
+Expected: PASS with exit code 0.
+
+- [ ] **Step 3: Measure startup time**
+
+Run:
+
+```bash
+cd /home/nixos/wkspace/worktree/refactor/nvim-performance
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+for i in $(seq 1 10); do
+  log="$tmpdir/startup-$i.log"
+  XDG_CONFIG_HOME="$PWD" nvim --headless --startuptime "$log" +qa >/dev/null 2>&1
+  awk '/NVIM STARTED/ { print $1 }' "$log"
+done | sort -n | awk '{ a[NR] = $1 } END { mid = int((NR + 1) / 2); printf("runs=%d median=%.3fms min=%.3fms max=%.3fms\n", NR, a[mid], a[1], a[NR]) }'
+```
+
+Expected: Reports startup timing without errors.
+
+- [ ] **Step 4: Run Nix verification**
+
+Run:
+
+```bash
+cd /home/nixos/wkspace/worktree/refactor/nvim-performance
+nix flake check
+home-manager switch --flake '.#nixos@wsl'
+```
+
+Expected: Both commands exit 0. The unqualified `home-manager switch --flake .` is expected to fail in this repo because the flake exposes named home configurations such as `nixos@wsl` rather than a default `nixos` configuration.
+
+- [ ] **Step 5: Describe jj change**
+
+Run:
+
+```bash
+cd /home/nixos/wkspace/worktree/refactor/nvim-performance
+jj describe -m ':zap: perf(neovim): optimize startup and preserve filer keymap'
+```
+
+Expected: Working copy description is updated.

--- a/docs/superpowers/specs/2026-06-01-neovim-startup-performance-design.md
+++ b/docs/superpowers/specs/2026-06-01-neovim-startup-performance-design.md
@@ -1,0 +1,41 @@
+# Neovim Startup Performance Design
+
+## Goal
+
+Make Neovim feel faster on launch while keeping the file explorer available from `<leader>e` in every buffer.
+
+## Scope
+
+- Preserve the existing mini.nvim-based setup.
+- Optimize empty `nvim` startup and common file-open startup.
+- Keep `<leader>e` and `<leader>E` dedicated to `mini.files`.
+- Move LSP line diagnostics away from `<leader>e`.
+- Keep package changes limited to Neovim startup support, LSP defaults, and automated verification.
+
+## Design
+
+Startup should load only core editor settings, keymaps, autocmd definitions, the active monochrome colorscheme, lightweight mini UI components, and enough lazy trigger functions to load tools on demand. Heavy Nix-managed plugins should be installed as optional packages and loaded with `:packadd` from events or keypresses: file explorer on `<leader>e`, picker on `<leader>f*` and LSP symbol keys, completion/snippets/pairs on `InsertEnter`, LSP/formatting/git helpers when editing real files, and DAP on debug key usage.
+
+The plugin configuration module will expose idempotent setup helpers so each feature initializes once. Keymaps will call helper functions instead of assuming plugins were loaded during startup.
+
+## Keymap changes
+
+- `<leader>e`: open `mini.files` at the current working directory.
+- `<leader>E`: open `mini.files` at the current file.
+- `<leader>cd`: show line diagnostics with Lspsaga after LSP attaches.
+- `<leader>e` will not be remapped by LSP buffer-local mappings.
+
+## Performance changes
+
+- Enable Neovim's Lua module cache with `vim.loader.enable()` when available.
+- Remove global Treesitter fold expression from startup; configure Treesitter folds buffer-locally after parser startup and keep folding disabled by default.
+- Apply the active local monochrome colorscheme directly; configure Catppuccin only before selecting Catppuccin.
+- Avoid loading starter/session/DAP/snippet/picker/LSP modules during empty startup.
+
+## Verification
+
+- Add a headless Lua regression test that fails if `<leader>e` does not call the file explorer helper before and after a synthetic `LspAttach` event.
+- Wire the Neovim regression test into `nix flake check` for x86_64-linux.
+- Run headless startup smoke tests.
+- Compare `nvim --startuptime` before and after the optimization.
+- Run `nix flake check` and `home-manager switch --flake .` from the workspace.

--- a/flake.nix
+++ b/flake.nix
@@ -140,7 +140,26 @@
 
       # Test checks
       checks = forAllSystems (system:
-        let pkgs = nixpkgsFor.${system};
+        let
+          pkgs = nixpkgsFor.${system};
+          linuxChecks = if system == "x86_64-linux" then {
+            nvim-config-tests = pkgs.runCommand "nvim-config-tests"
+              {
+                src = self;
+                nativeBuildInputs = [ self.homeConfigurations."nixos@wsl".config.programs.neovim.finalPackage ];
+              } ''
+              cp -R "$src" source
+              chmod -R u+w source
+              cd source
+              export XDG_CONFIG_HOME="$PWD"
+              export XDG_DATA_HOME="$TMPDIR/data"
+              export XDG_STATE_HOME="$TMPDIR/state"
+              export XDG_CACHE_HOME="$TMPDIR/cache"
+              nvim --headless +'luafile nvim/tests/leader_e_minifiles.lua' +'qa!'
+              nvim --headless nvim/init.lua +'lua assert(vim.fn.exists(":LspServers") == 2, "LspServers command missing"); local cfg = vim.lsp.config.lua_ls; assert(cfg and type(cfg.cmd) == "table" and #cfg.cmd > 0, "lua_ls cmd missing"); assert(vim.fn.maparg("<leader>l", "n") == "", "<leader>l maps to missing Lazy command")' +'qa!'
+              touch "$out"
+            '';
+          } else { };
         in {
           pi-goal-tests = pkgs.runCommand "pi-goal-tests"
             {
@@ -165,7 +184,7 @@
             node --test pi/subagents/core.test.ts
             touch "$out"
           '';
-        });
+        } // linuxChecks);
 
       # Development shell for testing
       devShells = forAllSystems (system:

--- a/modules/neovim.nix
+++ b/modules/neovim.nix
@@ -40,6 +40,9 @@
 
     # Plugins
     plugins = with pkgs.vimPlugins; [
+      # Mini.nvim core modules
+      mini-nvim
+
       # Treesitter for syntax highlighting
       # Use specific grammars instead of all for better performance
       (nvim-treesitter.withPlugins (p: [
@@ -69,28 +72,30 @@
         p.json
       ]))
 
-      # Color scheme
-      catppuccin-nvim
+      # Color scheme (loaded on demand)
+      { plugin = catppuccin-nvim; optional = true; }
 
-      # Snippet engine
-      luasnip
-      friendly-snippets
+      # Snippet engine (loaded on InsertEnter)
+      { plugin = luasnip; optional = true; }
+      { plugin = friendly-snippets; optional = true; }
 
-      # Formatter
-      conform-nvim
+      # Formatter (loaded when editing files)
+      { plugin = conform-nvim; optional = true; }
 
-      # Debugger
-      nvim-dap
-      nvim-dap-ui
-      nvim-dap-virtual-text
+      # Debugger (loaded from <leader>d mappings)
+      { plugin = nvim-nio; optional = true; }
+      { plugin = nvim-dap; optional = true; }
+      { plugin = nvim-dap-ui; optional = true; }
+      { plugin = nvim-dap-virtual-text; optional = true; }
 
-      # Keybinding helper
-      which-key-nvim
+      # Keybinding helper (loaded after first paint)
+      { plugin = which-key-nvim; optional = true; }
 
-      # LSP UI enhancement
-      lspsaga-nvim
+      # LSP defaults and UI enhancement (loaded when editing files)
+      { plugin = nvim-lspconfig; optional = true; }
+      { plugin = lspsaga-nvim; optional = true; }
 
-      # Mini.nvim will be bootstrapped in init.lua
+      # init.lua keeps a standalone mini.nvim bootstrap fallback for non-Nix use
     ];
   };
 

--- a/nvim/KEYMAPS.md
+++ b/nvim/KEYMAPS.md
@@ -58,6 +58,7 @@ Leader key: `<Space>`
 | `<leader>ws` | n | Workspace symbols |
 | `<leader>rn` | n | Rename symbol |
 | `<leader>ca` | n | Code action |
+| `<leader>cd` | n | Line diagnostics |
 | `<leader>cf` | n, v | Code format |
 | `<leader>wa` | n | Add workspace folder |
 | `<leader>wr` | n | Remove workspace folder |
@@ -69,8 +70,8 @@ Leader key: `<Space>`
 |-----|------|-------------|
 | `[d` | n | Previous diagnostic |
 | `]d` | n | Next diagnostic |
-| `<leader>e` | n | Open floating diagnostic |
-| `<leader>q` | n | Open diagnostics list |
+| `<leader>cd` | n | Open floating diagnostic |
+| `<leader>cl` | n | Open diagnostics list |
 
 ## Editing
 

--- a/nvim/README.md
+++ b/nvim/README.md
@@ -39,9 +39,9 @@ If you need just neovim configuration without the full Nix setup:
 
 ### Plugin management
 - **Mini.deps**: Automatic plugin management
-- **Lazy loading**: Plugins load when needed
-- **Bootstrap**: Auto-installs mini.nvim on first run
-- **No external dependencies**: Self-contained setup
+- **Lazy loading**: Heavy plugins load on first relevant event or keypress
+- **Bootstrap**: Nix provides mini.nvim; standalone installs still auto-bootstrap it
+- **Nix-managed dependencies**: Home Manager provides plugins/tools; heavy plugins are installed optional and loaded on demand
 
 ### LSP servers supported
 - **lua_ls**: Lua language server
@@ -73,6 +73,10 @@ If you need just neovim configuration without the full Nix setup:
 - `<leader>fm`: Find marks
 - `<leader>fo`: Find options
 
+**LSP diagnostics:**
+- `<leader>cd`: Show line diagnostics
+- `<leader>cl`: Open diagnostics list
+
 ### Configuration structure
 
 ```
@@ -102,6 +106,7 @@ nvim/
 - **mini.icons**: File type icons
 
 ### Code features
+- **nvim-lspconfig**: Language server defaults
 - **LSP**: Language server integration
 - **Diagnostics**: Error and warning display
 - **Formatting**: Code formatting support

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -1,18 +1,33 @@
 -- Neovim configuration with mini.nvim
 -- Modular configuration structure
 
--- Bootstrap mini.nvim
+-- Cache Lua modules when supported (Neovim 0.9+)
+if vim.loader then
+  vim.loader.enable()
+end
+
+-- Bootstrap mini.nvim. Nix provides mini.nvim for the Home Manager setup;
+-- cloning is only a fallback for standalone use.
 local path_package = vim.fn.stdpath('data') .. '/site/'
 local mini_path = path_package .. 'pack/deps/start/mini.nvim'
-if not vim.loop.fs_stat(mini_path) then
-  vim.cmd('echo "Installing `mini.nvim`" | redraw')
-  local clone_cmd = {
-    'git', 'clone', '--filter=blob:none',
-    'https://github.com/echasnovski/mini.nvim', mini_path
-  }
-  vim.fn.system(clone_cmd)
-  vim.cmd('packadd mini.nvim | helptags ALL')
-  vim.cmd('echo "Installed `mini.nvim`" | redraw')
+local has_mini_deps = pcall(require, 'mini.deps')
+if not has_mini_deps then
+  local uv = vim.uv or vim.loop
+  local installed = false
+  if not uv.fs_stat(mini_path) then
+    vim.cmd('echo "Installing `mini.nvim`" | redraw')
+    local clone_cmd = {
+      'git', 'clone', '--filter=blob:none',
+      'https://github.com/echasnovski/mini.nvim', mini_path,
+    }
+    vim.fn.system(clone_cmd)
+    installed = true
+    vim.cmd('echo "Installed `mini.nvim`" | redraw')
+  end
+  vim.cmd('packadd mini.nvim')
+  if installed then
+    vim.cmd('helptags ALL')
+  end
 end
 
 -- Load configuration modules
@@ -22,98 +37,99 @@ require('config.autocmds')  -- Auto commands
 
 -- Plugin manager
 require('mini.deps').setup({ path = { package = path_package } })
-local add, now, later = MiniDeps.add, MiniDeps.now, MiniDeps.later
 
--- Get plugins configuration
+-- Plugin configuration helpers
 local plugins = require('config.plugins')
 
--- Load which-key for keybinding hints
-now(function()
-  plugins.setup_whichkey()
-end)
+-- Startup-critical setup only
+plugins.setup_core()
+plugins.setup_colorscheme()
+plugins.setup_treesitter()
 
--- Load essential mini.nvim plugins immediately
-now(function()
-  plugins.setup_mini()
-  
-  -- Essential keymaps for mini.files
-  vim.keymap.set('n', '<leader>e', '<CMD>lua MiniFiles.open()<CR>', { desc = 'Open file explorer' })
-  vim.keymap.set('n', '<leader>E', '<CMD>lua MiniFiles.open(vim.api.nvim_buf_get_name(0))<CR>', { desc = 'Open file explorer at current file' })
-end)
+-- File explorer keymaps. These stay global so LSP buffers do not shadow them.
+vim.keymap.set('n', '<leader>e', function()
+  plugins.open_files()
+end, { desc = 'Open file explorer' })
+vim.keymap.set('n', '<leader>E', function()
+  plugins.open_files(vim.api.nvim_buf_get_name(0))
+end, { desc = 'Open file explorer at current file' })
 
--- Load completion and picker
-later(function()
-  plugins.setup_completion()
-  plugins.setup_picker()
-  
-  -- Fuzzy finder keymaps
-  vim.keymap.set('n', '<leader>ff', '<CMD>Pick files<CR>', { desc = 'Find files' })
-  vim.keymap.set('n', '<leader>fg', '<CMD>Pick grep_live<CR>', { desc = 'Live grep' })
-  vim.keymap.set('n', '<leader>fb', '<CMD>Pick buffers<CR>', { desc = 'Find buffers' })
-  vim.keymap.set('n', '<leader>fh', '<CMD>Pick help<CR>', { desc = 'Find help' })
-  vim.keymap.set('n', '<leader>fr', '<CMD>Pick oldfiles<CR>', { desc = 'Recent files' })
-  vim.keymap.set('n', '<leader>fd', '<CMD>Pick diagnostic<CR>', { desc = 'Find diagnostics' })
-  vim.keymap.set('n', '<leader>fk', '<CMD>Pick keymaps<CR>', { desc = 'Find keymaps' })
-  vim.keymap.set('n', '<leader>fc', '<CMD>Pick commands<CR>', { desc = 'Find commands' })
-  vim.keymap.set('n', '<leader>fm', '<CMD>Pick marks<CR>', { desc = 'Find marks' })
-  vim.keymap.set('n', '<leader>fo', '<CMD>Pick options<CR>', { desc = 'Find options' })
-end)
+-- Fuzzy finder keymaps lazy-load mini.pick and mini.extra on first use.
+vim.keymap.set('n', '<leader>ff', function() plugins.pick('files') end, { desc = 'Find files' })
+vim.keymap.set('n', '<leader>fg', function() plugins.pick('grep_live') end, { desc = 'Live grep' })
+vim.keymap.set('n', '<leader>fb', function() plugins.pick('buffers') end, { desc = 'Find buffers' })
+vim.keymap.set('n', '<leader>fh', function() plugins.pick('help') end, { desc = 'Find help' })
+vim.keymap.set('n', '<leader>fr', function() plugins.pick('oldfiles') end, { desc = 'Recent files' })
+vim.keymap.set('n', '<leader>fd', function() plugins.pick('diagnostic') end, { desc = 'Find diagnostics' })
+vim.keymap.set('n', '<leader>fk', function() plugins.pick('keymaps') end, { desc = 'Find keymaps' })
+vim.keymap.set('n', '<leader>fc', function() plugins.pick('commands') end, { desc = 'Find commands' })
+vim.keymap.set('n', '<leader>fm', function() plugins.pick('marks') end, { desc = 'Find marks' })
+vim.keymap.set('n', '<leader>fo', function() plugins.pick('options') end, { desc = 'Find options' })
+vim.keymap.set('n', '<leader>fC', function() plugins.pick_colorschemes() end, { desc = 'Pick colorscheme' })
 
--- Load git integration
-later(function()
-  plugins.setup_git()
-end)
+-- Debug keymaps lazy-load DAP on first use, then config.dap replaces these stubs.
+local function with_dap(callback)
+  return function()
+    plugins.setup_dap()
+    local ok, dap = pcall(require, 'dap')
+    if ok then
+      callback(dap)
+    end
+  end
+end
 
--- Load color scheme
-later(function()
-  -- Note: catppuccin-nvim is provided by Nix (see modules/neovim.nix)
-  -- The plugin is already available via Nix's packpath
+vim.keymap.set('n', '<leader>db', with_dap(function(dap) dap.toggle_breakpoint() end), { desc = '[D]ebug [B]reakpoint toggle' })
+vim.keymap.set('n', '<leader>dB', with_dap(function(dap)
+  dap.set_breakpoint(vim.fn.input('Breakpoint condition: '))
+end), { desc = '[D]ebug [B]reakpoint conditional' })
+vim.keymap.set('n', '<leader>dc', with_dap(function(dap) dap.continue() end), { desc = '[D]ebug [C]ontinue' })
+vim.keymap.set('n', '<leader>di', with_dap(function(dap) dap.step_into() end), { desc = '[D]ebug step [I]nto' })
+vim.keymap.set('n', '<leader>do', with_dap(function(dap) dap.step_over() end), { desc = '[D]ebug step [O]ver' })
+vim.keymap.set('n', '<leader>dO', with_dap(function(dap) dap.step_out() end), { desc = '[D]ebug step [O]ut' })
+vim.keymap.set('n', '<leader>dr', with_dap(function(dap) dap.repl.open() end), { desc = '[D]ebug [R]EPL' })
+vim.keymap.set('n', '<leader>dl', with_dap(function(dap) dap.run_last() end), { desc = '[D]ebug [L]ast' })
+vim.keymap.set('n', '<leader>dx', with_dap(function(dap) dap.terminate() end), { desc = '[D]ebug terminate' })
 
-  -- For non-Nix systems, you can uncomment the following:
-  -- add({
-  --   source = 'catppuccin/nvim',
-  --   name = 'catppuccin',
-  -- })
+local function with_dapui(callback)
+  return function()
+    plugins.setup_dap()
+    local ok, dapui = pcall(require, 'dapui')
+    if ok then
+      callback(dapui)
+    end
+  end
+end
 
-  plugins.setup_colorscheme()
-end)
+vim.keymap.set('n', '<leader>du', with_dapui(function(dapui) dapui.toggle() end), { desc = '[D]ebug [U]I toggle' })
+vim.keymap.set('n', '<leader>de', with_dapui(function(dapui) dapui.eval() end), { desc = '[D]ebug [E]val' })
+vim.keymap.set('v', '<leader>de', with_dapui(function(dapui) dapui.eval() end), { desc = '[D]ebug [E]val' })
 
--- Load treesitter
-later(function()
-  -- Note: nvim-treesitter is provided by Nix (see modules/neovim.nix)
-  -- The plugin is already available via Nix's packpath
-  -- We don't need to use mini.deps to download it again
+-- Load editing features when they become useful, not during empty startup.
+local lazy_group = vim.api.nvim_create_augroup('LazyPluginSetup', { clear = true })
 
-  -- For non-Nix systems, you can uncomment the following:
-  -- add({
-  --   source = 'nvim-treesitter/nvim-treesitter',
-  --   hooks = {
-  --     post_checkout = function()
-  --       vim.cmd('TSUpdate')
-  --     end,
-  --   },
-  -- })
+vim.api.nvim_create_autocmd('InsertEnter', {
+  group = lazy_group,
+  once = true,
+  callback = function()
+    plugins.setup_editing()
+    plugins.setup_completion()
+    plugins.setup_format()
+    require('config.snippets').setup()
+  end,
+})
 
-  plugins.setup_treesitter()
-end)
+vim.api.nvim_create_autocmd({ 'BufReadPre', 'BufNewFile' }, {
+  group = lazy_group,
+  once = true,
+  callback = function()
+    plugins.setup_editing()
+    plugins.setup_git()
+    plugins.setup_lsp()
+    plugins.setup_format()
+  end,
+})
 
--- LSP configuration
-later(function()
-  plugins.setup_lspsaga()
-  require('config.lsp').setup()
-end)
-
--- Snippet engine
-later(function()
-  require('config.snippets').setup()
-end)
-
--- Formatter configuration
-later(function()
-  require('config.format').setup()
-end)
-
--- Debug Adapter Protocol
-later(function()
-  require('config.dap').setup()
-end)
+-- which-key is useful, but it does not need to block first paint.
+vim.defer_fn(function()
+  pcall(plugins.setup_whichkey)
+end, 100)

--- a/nvim/lua/config/autocmds.lua
+++ b/nvim/lua/config/autocmds.lua
@@ -138,7 +138,7 @@ autocmd("LspAttach", {
     -- Lspsaga diagnostics
     map('[d', '<cmd>Lspsaga diagnostic_jump_prev<cr>', 'Prev Diagnostic')
     map(']d', '<cmd>Lspsaga diagnostic_jump_next<cr>', 'Next Diagnostic')
-    map('<leader>e', '<cmd>Lspsaga show_line_diagnostics<cr>', 'Line Diagnostics')
+    map('<leader>cd', '<cmd>Lspsaga show_line_diagnostics<cr>', 'Line Diagnostics')
 
     -- Lspsaga code actions and rename
     map('<leader>ca', '<cmd>Lspsaga code_action<cr>', 'Code Action')
@@ -154,13 +154,13 @@ autocmd("LspAttach", {
     -- Mini.extra pickers for LSP symbols
     -- (wrapped in functions so the picker is invoked on keypress, not at LspAttach)
     map('<leader>D', function()
-      require('mini.extra').pickers.lsp({ scope = 'type_definition' })
+      require('config.plugins').pick_lsp('type_definition')
     end, 'Type Definition')
     map('<leader>ds', function()
-      require('mini.extra').pickers.lsp({ scope = 'document_symbol' })
+      require('config.plugins').pick_lsp('document_symbol')
     end, 'Document Symbols')
     map('<leader>ws', function()
-      require('mini.extra').pickers.lsp({ scope = 'workspace_symbol' })
+      require('config.plugins').pick_lsp('workspace_symbol')
     end, 'Workspace Symbols')
 
     -- Workspace folder management

--- a/nvim/lua/config/keymaps.lua
+++ b/nvim/lua/config/keymaps.lua
@@ -57,9 +57,6 @@ map({ "i", "x", "n", "s" }, "<C-s>", "<cmd>w<cr><esc>", { desc = "Save file" })
 map("v", "<", "<gv")
 map("v", ">", ">gv")
 
--- Lazy
-map("n", "<leader>l", "<cmd>Lazy<cr>", { desc = "Lazy" })
-
 -- New file
 map("n", "<leader>fn", "<cmd>enew<cr>", { desc = "New File" })
 
@@ -115,5 +112,5 @@ map("i", ";", ";<c-g>u")
 -- Search and replace
 map("n", "<leader>sr", ":%s/\\<<C-r><C-w>\\>/<C-r><C-w>/gI<Left><Left><Left>", { desc = "Search and replace word under cursor" })
 
--- Diagnostic keymaps (lspsaga will override [d, ]d, <leader>e when LSP is attached)
-map("n", "<leader>q", vim.diagnostic.setloclist, { desc = "Open diagnostics list" })
+-- Diagnostic keymaps (Lspsaga adds enhanced diagnostic navigation when LSP is attached)
+map("n", "<leader>cl", vim.diagnostic.setloclist, { desc = "Open diagnostics list" })

--- a/nvim/lua/config/options.lua
+++ b/nvim/lua/config/options.lua
@@ -54,13 +54,13 @@ vim.opt.autoindent = true
 vim.opt.mouse = 'a'
 vim.opt.clipboard = 'unnamedplus'
 
--- Folding (using built-in Neovim treesitter API)
-vim.opt.foldmethod = 'expr'
-vim.opt.foldexpr = 'v:lua.vim.treesitter.foldexpr()'
+-- Folding defaults stay cheap during startup. Treesitter-enabled buffers set
+-- buffer-local fold expressions after their parser starts.
+vim.opt.foldmethod = 'manual'
 vim.opt.foldtext = ''  -- Use default fold text (shows first line)
 vim.opt.foldlevel = 99
 vim.opt.foldlevelstart = 99
-vim.opt.foldenable = true
+vim.opt.foldenable = false
 
 -- Window title
 vim.opt.title = true

--- a/nvim/lua/config/plugins.lua
+++ b/nvim/lua/config/plugins.lua
@@ -2,230 +2,272 @@
 
 local M = {}
 
--- Mini.nvim plugins setup
-M.setup_mini = function()
-  -- Mini.basics
-  require('mini.basics').setup({
-    options = {
-      basic = true,
-      extra_ui = true,
-      win_borders = 'default',
-    },
-    mappings = {
-      basic = true,
-      option_toggle_prefix = [[\]],
-      windows = true,
-      move_with_alt = true,
-    },
-    autocommands = {
-      basic = true,
-      relnum_in_visual_mode = true,
-    },
-    silent = false,
-  })
+local loaded = {}
 
-  -- Mini.files (file explorer)
-  require('mini.files').setup({
-    mappings = {
-      close       = 'q',
-      go_in       = 'l',
-      go_in_plus  = '<CR>',
-      go_out      = 'h',
-      go_out_plus = '-',
-      reset       = '<BS>',
-      reveal_cwd  = '@',
-      show_help   = 'g?',
-      synchronize = '=',
-      trim_left   = '<',
-      trim_right  = '>',
-    },
-    windows = {
-      preview = true,
-      width_focus = 30,
-      width_preview = 60,
-    },
-  })
+local function setup_once(name, callback)
+  if loaded[name] then return end
+  loaded[name] = true
+  callback()
+end
 
-  -- Mini.statusline
-  require('mini.statusline').setup({
-    use_icons = true,
-    set_vim_settings = true,
-  })
+local function packadd(name)
+  pcall(vim.cmd, 'packadd ' .. name)
+end
 
-  -- Mini.tabline
-  require('mini.tabline').setup()
+-- Core mini.nvim plugins needed during startup
+M.setup_core = function()
+  setup_once('core', function()
+    -- Mini.basics
+    require('mini.basics').setup({
+      options = {
+        basic = true,
+        extra_ui = true,
+        win_borders = 'default',
+      },
+      mappings = {
+        basic = true,
+        option_toggle_prefix = [[\]],
+        windows = true,
+        move_with_alt = true,
+      },
+      autocommands = {
+        basic = true,
+        relnum_in_visual_mode = true,
+      },
+      silent = false,
+    })
 
-  -- Mini.comment
-  require('mini.comment').setup()
+    -- Mini.statusline
+    require('mini.statusline').setup({
+      use_icons = true,
+      set_vim_settings = true,
+    })
 
-  -- Mini.surround
-  require('mini.surround').setup()
+    -- Mini.tabline
+    require('mini.tabline').setup()
+  end)
+end
 
-  -- Mini.pairs
-  require('mini.pairs').setup()
+-- Mini.files (file explorer)
+M.setup_files = function()
+  setup_once('files', function()
+    require('mini.files').setup({
+      mappings = {
+        close       = 'q',
+        go_in       = 'l',
+        go_in_plus  = '<CR>',
+        go_out      = 'h',
+        go_out_plus = '-',
+        reset       = '<BS>',
+        reveal_cwd  = '@',
+        show_help   = 'g?',
+        synchronize = '=',
+        trim_left   = '<',
+        trim_right  = '>',
+      },
+      windows = {
+        preview = true,
+        width_focus = 30,
+        width_preview = 60,
+      },
+    })
+  end)
+end
 
-  -- Mini.ai (better text objects)
-  require('mini.ai').setup()
+M.open_files = function(path)
+  M.setup_files()
+  if path == '' then
+    path = nil
+  end
+  MiniFiles.open(path)
+end
 
-  -- Mini.splitjoin
-  require('mini.splitjoin').setup()
+-- Editing helpers that are useful for real buffers, but not needed for first paint
+M.setup_editing = function()
+  setup_once('editing', function()
+    -- Mini.comment
+    require('mini.comment').setup()
 
-  -- Mini.indentscope
-  require('mini.indentscope').setup({
-    symbol = '│',
-    draw = {
-      delay = 100,
-      animation = require('mini.indentscope').gen_animation.none(),
-    },
-  })
+    -- Mini.surround
+    require('mini.surround').setup()
 
-  -- Mini.hipatterns
-  require('mini.hipatterns').setup({
-    highlighters = {
-      fixme = { pattern = '%f[%w]()FIXME()%f[%W]', group = 'MiniHipatternsFixme' },
-      hack  = { pattern = '%f[%w]()HACK()%f[%W]',  group = 'MiniHipatternsHack'  },
-      todo  = { pattern = '%f[%w]()TODO()%f[%W]',  group = 'MiniHipatternsTodo'  },
-      note  = { pattern = '%f[%w]()NOTE()%f[%W]',  group = 'MiniHipatternsNote'  },
-    },
-  })
+    -- Mini.pairs
+    require('mini.pairs').setup()
 
-  -- Mini.trailspace
-  require('mini.trailspace').setup()
+    -- Mini.ai (better text objects)
+    require('mini.ai').setup()
 
-  -- Mini.sessions
-  require('mini.sessions').setup({
-    autoread = false,
-    autowrite = true,
-    directory = vim.fn.stdpath('state') .. '/sessions',
-    file = 'session.vim',
-  })
+    -- Mini.splitjoin
+    require('mini.splitjoin').setup()
 
-  -- Mini.starter
-  require('mini.starter').setup({
-    evaluate_single = true,
-    items = {
-      require('mini.starter').sections.builtin_actions(),
-      require('mini.starter').sections.recent_files(5, false),
-      require('mini.starter').sections.recent_files(5, true),
-      require('mini.starter').sections.sessions(5, true),
-    },
-    content_hooks = {
-      require('mini.starter').gen_hook.adding_bullet(),
-      require('mini.starter').gen_hook.aligning('center', 'center'),
-    },
-  })
+    -- Mini.indentscope
+    require('mini.indentscope').setup({
+      symbol = '│',
+      draw = {
+        delay = 100,
+        animation = require('mini.indentscope').gen_animation.none(),
+      },
+    })
+
+    -- Mini.hipatterns
+    require('mini.hipatterns').setup({
+      highlighters = {
+        fixme = { pattern = '%f[%w]()FIXME()%f[%W]', group = 'MiniHipatternsFixme' },
+        hack  = { pattern = '%f[%w]()HACK()%f[%W]',  group = 'MiniHipatternsHack'  },
+        todo  = { pattern = '%f[%w]()TODO()%f[%W]',  group = 'MiniHipatternsTodo'  },
+        note  = { pattern = '%f[%w]()NOTE()%f[%W]',  group = 'MiniHipatternsNote'  },
+      },
+    })
+
+    -- Mini.trailspace
+    require('mini.trailspace').setup()
+  end)
 end
 
 -- Setup completion
 M.setup_completion = function()
-  require('mini.completion').setup({
-    delay = { completion = 100, info = 100, signature = 50 },
-    window = {
-      info = { height = 25, width = 80, border = 'single' },
-      signature = { height = 25, width = 80, border = 'single' },
-    },
-    lsp_completion = {
-      source_func = 'omnifunc',
-      auto_setup = false,
-    },
-    fallback_action = '<C-x><C-n>',
-  })
+  setup_once('completion', function()
+    require('mini.completion').setup({
+      delay = { completion = 100, info = 100, signature = 50 },
+      window = {
+        info = { height = 25, width = 80, border = 'single' },
+        signature = { height = 25, width = 80, border = 'single' },
+      },
+      lsp_completion = {
+        source_func = 'omnifunc',
+        auto_setup = false,
+      },
+      fallback_action = '<C-x><C-n>',
+    })
+  end)
 end
 
 -- Setup fuzzy finder
 M.setup_picker = function()
-  require('mini.pick').setup()
-  require('mini.extra').setup()
+  setup_once('picker', function()
+    require('mini.pick').setup()
+    require('mini.extra').setup()
+  end)
+end
+
+M.pick = function(source)
+  M.setup_picker()
+  vim.cmd('Pick ' .. source)
+end
+
+M.pick_colorschemes = function()
+  M.setup_picker()
+  require('mini.extra').pickers.colorschemes()
+end
+
+M.pick_lsp = function(scope)
+  M.setup_picker()
+  require('mini.extra').pickers.lsp({ scope = scope })
 end
 
 -- Setup git integration
 M.setup_git = function()
-  require('mini.git').setup()
-  require('mini.diff').setup({
-    view = {
-      style = 'sign',
-      signs = { add = '+', change = '~', delete = '-' },
-    },
-  })
+  setup_once('git', function()
+    require('mini.git').setup()
+    require('mini.diff').setup({
+      view = {
+        style = 'sign',
+        signs = { add = '+', change = '~', delete = '-' },
+      },
+    })
+  end)
+end
+
+-- Setup Catppuccin only when it is selected
+M.setup_catppuccin = function()
+  setup_once('catppuccin', function()
+    packadd('catppuccin-nvim')
+    require('catppuccin').setup({
+      flavour = 'latte',
+      transparent_background = false,
+      term_colors = true,
+      color_overrides = {
+        latte = {
+          -- Base colors matching Wezterm warm palette
+          base = '#fefdf8',      -- soft warm white background
+          mantle = '#faf8f3',    -- very light warm white
+          crust = '#f5ede3',     -- cream
+
+          -- Text colors
+          text = '#5c4d3d',      -- warm brown foreground
+          subtext1 = '#6d5d4d',  -- slightly lighter brown
+          subtext0 = '#8b7355',  -- medium brown
+
+          -- Overlay colors
+          overlay2 = '#a89888',  -- light brown
+          overlay1 = '#c5b5a5',  -- lighter brown
+          overlay0 = '#e6d5c3',  -- light tan
+
+          -- Surface colors
+          surface2 = '#f5e6d3',  -- light beige (selection)
+          surface1 = '#f5ede3',  -- cream
+          surface0 = '#faf8f3',  -- very light warm white
+
+          -- Accent colors from warm palette
+          blue = '#7c8fa3',      -- muted slate
+          lavender = '#97aec2',  -- light slate
+          sapphire = '#8ea59d',  -- sage
+          sky = '#abd5c9',       -- mint
+          teal = '#8ea59d',      -- sage cyan
+          green = '#8a9a5b',     -- olive
+          yellow = '#d99545',    -- amber
+          peach = '#d97742',     -- warm orange (primary accent)
+          maroon = '#c04f30',    -- terracotta
+          red = '#c04f30',       -- terracotta red
+          mauve = '#a06469',     -- dusty rose
+          pink = '#b88b8f',      -- rose
+          flamingo = '#b88b8f',  -- rose
+          rosewater = '#d97742', -- warm orange
+        },
+      },
+      integrations = {
+        mini = {
+          enabled = true,
+          indentscope_color = '',
+        },
+      },
+    })
+  end)
+end
+
+M.apply_colorscheme = function(name)
+  if name == 'catppuccin' then
+    M.setup_catppuccin()
+  end
+  vim.cmd.colorscheme(name)
 end
 
 -- Setup color scheme
 M.setup_colorscheme = function()
-  require('catppuccin').setup({
-    flavour = 'latte',
-    transparent_background = false,
-    term_colors = true,
-    color_overrides = {
-      latte = {
-        -- Base colors matching Wezterm warm palette
-        base = '#fefdf8',      -- soft warm white background
-        mantle = '#faf8f3',    -- very light warm white
-        crust = '#f5ede3',     -- cream
+  setup_once('colorscheme', function()
+    -- Active scheme: monochrome-light-cool-gray (see nvim/colors/).
+    -- Catppuccin is configured lazily only when selected.
+    M.apply_colorscheme('monochrome-light-cool-gray')
 
-        -- Text colors
-        text = '#5c4d3d',      -- warm brown foreground
-        subtext1 = '#6d5d4d',  -- slightly lighter brown
-        subtext0 = '#8b7355',  -- medium brown
-
-        -- Overlay colors
-        overlay2 = '#a89888',  -- light brown
-        overlay1 = '#c5b5a5',  -- lighter brown
-        overlay0 = '#e6d5c3',  -- light tan
-
-        -- Surface colors
-        surface2 = '#f5e6d3',  -- light beige (selection)
-        surface1 = '#f5ede3',  -- cream
-        surface0 = '#faf8f3',  -- very light warm white
-
-        -- Accent colors from warm palette
-        blue = '#7c8fa3',      -- muted slate
-        lavender = '#97aec2',  -- light slate
-        sapphire = '#8ea59d',  -- sage
-        sky = '#abd5c9',       -- mint
-        teal = '#8ea59d',      -- sage cyan
-        green = '#8a9a5b',     -- olive
-        yellow = '#d99545',    -- amber
-        peach = '#d97742',     -- warm orange (primary accent)
-        maroon = '#c04f30',    -- terracotta
-        red = '#c04f30',       -- terracotta red
-        mauve = '#a06469',     -- dusty rose
-        pink = '#b88b8f',      -- rose
-        flamingo = '#b88b8f',  -- rose
-        rosewater = '#d97742', -- warm orange
-      },
-    },
-    integrations = {
-      mini = {
-        enabled = true,
-        indentscope_color = '',
-      },
-    },
-  })
-  -- Active scheme: monochrome-light-cool-gray (see nvim/colors/).
-  -- Catppuccin is still configured above and can be activated with
-  -- `:colorscheme catppuccin`.
-  vim.cmd.colorscheme('monochrome-light-cool-gray')
-
-  -- Cycle through the curated colorscheme list with <leader>uc.
-  local schemes = {
-    'monochrome-light-cool-gray',
-    'monochrome-dark-cool-gray',
-    'catppuccin',
-  }
-  vim.keymap.set('n', '<leader>uc', function()
-    local current = vim.g.colors_name
-    local next_idx = 1
-    for i, s in ipairs(schemes) do
-      if s == current then next_idx = (i % #schemes) + 1 break end
-    end
-    vim.cmd.colorscheme(schemes[next_idx])
-    vim.notify('colorscheme: ' .. schemes[next_idx])
-  end, { desc = 'Cycle colorscheme' })
-
-  -- Live-preview picker over every installed colorscheme.
-  vim.keymap.set('n', '<leader>fC', function()
-    require('mini.extra').pickers.colorschemes()
-  end, { desc = 'Pick colorscheme' })
+    -- Cycle through the curated colorscheme list with <leader>uc.
+    local schemes = {
+      'monochrome-light-cool-gray',
+      'monochrome-dark-cool-gray',
+      'catppuccin',
+    }
+    vim.keymap.set('n', '<leader>uc', function()
+      local current = vim.g.colors_name
+      local next_idx = 1
+      for i, s in ipairs(schemes) do
+        if s == current then
+          next_idx = (i % #schemes) + 1
+          break
+        end
+      end
+      M.apply_colorscheme(schemes[next_idx])
+      vim.notify('colorscheme: ' .. schemes[next_idx])
+    end, { desc = 'Cycle colorscheme' })
+  end)
 end
 
 -- Setup treesitter
@@ -233,114 +275,157 @@ end
 -- Highlighting and indent are now handled by Neovim's built-in vim.treesitter
 -- Parsers are managed by Nix (see modules/neovim.nix)
 M.setup_treesitter = function()
-  -- Enable treesitter-based highlighting for all supported filetypes
-  vim.api.nvim_create_autocmd('FileType', {
-    callback = function(args)
-      -- Skip for very large files (100KB+)
-      local max_filesize = 100 * 1024
-      local ok, stats = pcall(vim.uv.fs_stat, vim.api.nvim_buf_get_name(args.buf))
-      if ok and stats and stats.size > max_filesize then
-        return
-      end
+  setup_once('treesitter', function()
+    -- Enable treesitter-based highlighting for all supported filetypes
+    vim.api.nvim_create_autocmd('FileType', {
+      callback = function(args)
+        -- Skip for very large files (100KB+)
+        local max_filesize = 100 * 1024
+        local ok, stats = pcall(vim.uv.fs_stat, vim.api.nvim_buf_get_name(args.buf))
+        if ok and stats and stats.size > max_filesize then
+          return
+        end
 
-      -- Start treesitter highlighting if parser is available
-      local lang = vim.treesitter.language.get_lang(args.match)
-      if lang and pcall(vim.treesitter.start, args.buf, lang) then
-        -- Enable treesitter-based indentation
-        vim.bo[args.buf].indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
-      end
-    end,
-  })
+        -- Start treesitter highlighting if parser is available
+        local lang = vim.treesitter.language.get_lang(args.match)
+        if lang and pcall(vim.treesitter.start, args.buf, lang) then
+          -- Enable treesitter-based indentation and cheap, opt-in folds.
+          vim.bo[args.buf].indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
 
-  -- Incremental selection using built-in vim.treesitter API
-  -- (nvim-treesitter v1.0+ removed the incremental_selection module)
-  local selection_stack = {}
+          for _, win in ipairs(vim.fn.win_findbuf(args.buf)) do
+            vim.api.nvim_set_option_value('foldmethod', 'expr', { win = win })
+            vim.api.nvim_set_option_value('foldexpr', 'v:lua.vim.treesitter.foldexpr()', { win = win })
+            vim.api.nvim_set_option_value('foldtext', '', { win = win })
+            vim.api.nvim_set_option_value('foldlevel', 99, { win = win })
+            vim.api.nvim_set_option_value('foldenable', false, { win = win })
+          end
+        end
+      end,
+    })
 
-  local function select_node(node)
-    if not node then return end
-    local start_row, start_col, end_row, end_col = node:range()
-    vim.api.nvim_buf_set_mark(0, '<', start_row + 1, start_col, {})
-    vim.api.nvim_buf_set_mark(0, '>', end_row + 1, end_col - 1, {})
-    vim.cmd('normal! gv')
-  end
+    -- Incremental selection using built-in vim.treesitter API
+    -- (nvim-treesitter v1.0+ removed the incremental_selection module)
+    local selection_stack = {}
 
-  local function init_selection()
-    selection_stack = {}
-    local node = vim.treesitter.get_node()
-    if node then
-      table.insert(selection_stack, node)
-      select_node(node)
+    local function select_node(node)
+      if not node then return end
+      local start_row, start_col, end_row, end_col = node:range()
+      vim.api.nvim_buf_set_mark(0, '<', start_row + 1, start_col, {})
+      vim.api.nvim_buf_set_mark(0, '>', end_row + 1, end_col - 1, {})
+      vim.cmd('normal! gv')
     end
-  end
 
-  local function node_incremental()
-    local node = selection_stack[#selection_stack]
-    if not node then
-      node = vim.treesitter.get_node()
-    end
-    if node then
-      local parent = node:parent()
-      if parent then
-        table.insert(selection_stack, parent)
-        select_node(parent)
+    local function init_selection()
+      selection_stack = {}
+      local node = vim.treesitter.get_node()
+      if node then
+        table.insert(selection_stack, node)
+        select_node(node)
       end
     end
-  end
 
-  local function node_decremental()
-    if #selection_stack > 1 then
-      table.remove(selection_stack)
-      select_node(selection_stack[#selection_stack])
+    local function node_incremental()
+      local node = selection_stack[#selection_stack]
+      if not node then
+        node = vim.treesitter.get_node()
+      end
+      if node then
+        local parent = node:parent()
+        if parent then
+          table.insert(selection_stack, parent)
+          select_node(parent)
+        end
+      end
     end
-  end
 
-  vim.keymap.set('n', '<C-space>', init_selection, { desc = 'Start incremental selection' })
-  vim.keymap.set('x', '<C-space>', node_incremental, { desc = 'Increment selection to node' })
-  vim.keymap.set('x', '<bs>', node_decremental, { desc = 'Decrement selection to node' })
+    local function node_decremental()
+      if #selection_stack > 1 then
+        table.remove(selection_stack)
+        select_node(selection_stack[#selection_stack])
+      end
+    end
+
+    vim.keymap.set('n', '<C-space>', init_selection, { desc = 'Start incremental selection' })
+    vim.keymap.set('x', '<C-space>', node_incremental, { desc = 'Increment selection to node' })
+    vim.keymap.set('x', '<bs>', node_decremental, { desc = 'Decrement selection to node' })
+  end)
 end
 
 -- Setup lspsaga
 M.setup_lspsaga = function()
-  require('lspsaga').setup({
-    ui = {
-      border = 'rounded',
-      code_action = '󰌵',
-    },
-    lightbulb = {
-      enable = false,
-    },
-    symbol_in_winbar = {
-      enable = false,
-    },
-    outline = {
-      layout = 'float',
-    },
-  })
+  setup_once('lspsaga', function()
+    packadd('lspsaga.nvim')
+    require('lspsaga').setup({
+      ui = {
+        border = 'rounded',
+        code_action = '󰌵',
+      },
+      lightbulb = {
+        enable = false,
+      },
+      symbol_in_winbar = {
+        enable = false,
+      },
+      outline = {
+        layout = 'float',
+      },
+    })
+  end)
+end
+
+-- Setup LSP
+M.setup_lsp = function()
+  setup_once('lsp', function()
+    packadd('nvim-lspconfig')
+    M.setup_lspsaga()
+    require('config.lsp').setup()
+  end)
+end
+
+-- Setup formatter
+M.setup_format = function()
+  setup_once('format', function()
+    packadd('conform.nvim')
+    require('config.format').setup()
+  end)
+end
+
+-- Setup DAP
+M.setup_dap = function()
+  setup_once('dap', function()
+    packadd('nvim-nio')
+    packadd('nvim-dap')
+    packadd('nvim-dap-ui')
+    packadd('nvim-dap-virtual-text')
+    require('config.dap').setup()
+  end)
 end
 
 -- Setup which-key
 M.setup_whichkey = function()
-  local wk = require('which-key')
-  wk.setup({
-    preset = 'modern',
-    delay = 300,
-    icons = {
-      mappings = false,
-      rules = false,
-    },
-    spec = {
-      { '<leader>b', group = 'buffer' },
-      { '<leader>c', group = 'code' },
-      { '<leader>d', group = 'debug' },
-      { '<leader>f', group = 'find' },
-      { '<leader>g', group = 'git' },
-      { '<leader>s', group = 'search' },
-      { '<leader>u', group = 'ui/toggle' },
-      { '<leader>w', group = 'window' },
-      { '<leader><tab>', group = 'tab' },
-    },
-  })
+  setup_once('whichkey', function()
+    packadd('which-key.nvim')
+    local wk = require('which-key')
+    wk.setup({
+      preset = 'modern',
+      delay = 300,
+      icons = {
+        mappings = false,
+        rules = false,
+      },
+      spec = {
+        { '<leader>b', group = 'buffer' },
+        { '<leader>c', group = 'code' },
+        { '<leader>d', group = 'debug' },
+        { '<leader>f', group = 'find' },
+        { '<leader>g', group = 'git' },
+        { '<leader>s', group = 'search' },
+        { '<leader>u', group = 'ui/toggle' },
+        { '<leader>w', group = 'window' },
+        { '<leader><tab>', group = 'tab' },
+      },
+    })
+  end)
 end
 
 return M
-

--- a/nvim/lua/config/snippets.lua
+++ b/nvim/lua/config/snippets.lua
@@ -4,6 +4,9 @@
 local M = {}
 
 M.setup = function()
+  pcall(vim.cmd, 'packadd luasnip')
+  pcall(vim.cmd, 'packadd friendly-snippets')
+
   local ok, luasnip = pcall(require, 'luasnip')
   if not ok then
     return

--- a/nvim/tests/leader_e_minifiles.lua
+++ b/nvim/tests/leader_e_minifiles.lua
@@ -1,0 +1,53 @@
+local plugins = require('config.plugins')
+
+assert(type(plugins.open_files) == 'function', 'config.plugins.open_files must exist')
+
+local function assert_open_files_loads_minifiles()
+  local ok, err = pcall(function()
+    plugins.open_files()
+  end)
+
+  assert(ok, 'config.plugins.open_files() errored: ' .. tostring(err))
+  assert(_G.MiniFiles and type(MiniFiles.open) == 'function', 'MiniFiles.open was not loaded')
+
+  if type(MiniFiles.close) == 'function' then
+    pcall(MiniFiles.close)
+  end
+end
+
+local function assert_map_invokes_file_explorer(lhs, expected_path, label)
+  local call = { seen = false, path = nil }
+  local original = plugins.open_files
+
+  plugins.open_files = function(path)
+    call.seen = true
+    call.path = path
+  end
+
+  local ok, err = pcall(function()
+    vim.api.nvim_feedkeys(vim.keycode(lhs), 'xt', false)
+  end)
+
+  plugins.open_files = original
+
+  assert(ok, label .. ': pressing ' .. lhs .. ' errored: ' .. tostring(err))
+  assert(call.seen, label .. ': ' .. lhs .. ' did not invoke config.plugins.open_files(); effective map = ' .. vim.inspect(vim.fn.maparg(lhs, 'n', false, true)))
+  assert(call.path == expected_path, label .. ': ' .. lhs .. ' passed path ' .. vim.inspect(call.path) .. ', expected ' .. vim.inspect(expected_path))
+end
+
+local function assert_file_explorer_maps(label)
+  assert_map_invokes_file_explorer('<leader>e', nil, label)
+  assert_map_invokes_file_explorer('<leader>E', vim.api.nvim_buf_get_name(0), label)
+end
+
+assert_open_files_loads_minifiles()
+assert_file_explorer_maps('startup')
+
+local buf = vim.api.nvim_create_buf(true, false)
+vim.api.nvim_set_current_buf(buf)
+vim.api.nvim_exec_autocmds('LspAttach', {
+  buffer = buf,
+  data = { client_id = 1 },
+})
+
+assert_file_explorer_maps('after LspAttach')


### PR DESCRIPTION
## Summary
- Lazy-load Neovim integrations and optional Nix plugins to reduce startup work.
- Keep `<leader>e` / `<leader>E` dedicated to MiniFiles; move diagnostics to `<leader>cd` / `<leader>cl`.
- Add headless Neovim regression coverage to `nix flake check`.

## Test Plan
- `nvim --headless +'luafile nvim/tests/leader_e_minifiles.lua' +'qa!'`
- `nvim --headless nvim/init.lua +'lua assert(vim.fn.exists(":LspServers") == 2, "LspServers command missing"); local cfg = vim.lsp.config.lua_ls; assert(cfg and type(cfg.cmd) == "table" and #cfg.cmd > 0, "lua_ls cmd missing"); assert(vim.fn.maparg("<leader>l", "n") == "", "<leader>l maps to missing Lazy command")' +qa`
- `nix flake check`
- `home-manager switch --flake '.#nixos@wsl'`
- Startup benchmark: `nvim --headless --startuptime` median 28.116ms over 10 runs

## Notes
- Home Manager emits existing warnings about untrusted substituters, Neovim Python/Ruby defaults, Home Manager/Nixpkgs version mismatch, and `swww` rename.
