### PR TITLE
:arrow_up: chore(flake): track nixpkgs-unstable to match home-manager

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1780109978,
-        "narHash": "sha256-MJU0BV9Ihh8hbH7gVVNJR9W9sHbPLEEl2wcH7ZHsVGc=",
+        "lastModified": 1780258872,
+        "narHash": "sha256-VHzkE0xzvMKKI+iHBdqPWNFSPIpr+5QRwQsLjMfwIKE=",
         "owner": "ryoppippi",
         "repo": "claude-code-overlay",
-        "rev": "279cb23826e0cf43de5036dda1ba34a68599e171",
+        "rev": "7c80c9aa86a9ed59f5902d0d3a00a2c1d9df910c",
         "type": "github"
       },
       "original": {
@@ -88,16 +88,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1780246643,
+        "narHash": "sha256-4T1KWX7xWGQMs9hNZ24IOY3aYOi8D6+5WtkNRBSttB8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "3109eaae18e09d0b8aef23dc2579e7d94b8d4b4e",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -124,11 +124,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1780125618,
-        "narHash": "sha256-PGHDdAA+s8LPcj3fYzI1SMMGdNe9CZF08Qf25mLYiAc=",
+        "lastModified": 1780306633,
+        "narHash": "sha256-f6263HSQ4tdmPYcRpIfH3oFxiigBwcXh7I78rXmzwGU=",
         "owner": "lukasl-dev",
         "repo": "pi.nix",
-        "rev": "54c90546e12ddb900fa0e90c12fb1a8c011aee3d",
+        "rev": "184761dcc76756d3834acb576b9f3229d5afd084",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,10 @@
   description = "Cross-platform dotfiles with Home Manager";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    # nixpkgs-unstable (not nixos-unstable): faster-moving Hydra channel that
+    # stays version-aligned with home-manager's master branch. nixos-unstable
+    # lags around release time and triggers HM's version-mismatch warning.
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
     home-manager = {
       url = "github:nix-community/home-manager";


### PR DESCRIPTION
## Problem

After `./install.sh --update`, every rebuild warns:

> Home Manager version 26.11 and Nixpkgs version 26.05.
> Using mismatched versions is likely to cause errors and unexpected behavior.

**Root cause:** `home-manager` follows its `master` branch (already bumped to release **26.11**), while `nixpkgs` tracked `nixos-unstable`, whose Hydra channel is frozen at a **26.05** commit (2026-05-23). Home Manager's `modules/misc/version.nix` compares the two release strings and warns. The `inputs.nixpkgs.follows` wiring was correct — the two *branches* were simply one release apart.

## Fix

Switch `nixpkgs` to the `nixpkgs-unstable` channel:

| ref | version | cached |
| --- | --- | --- |
| `nixos-unstable` (before) | 26.05 (frozen since 2026-05-23) | yes |
| `nixpkgs-unstable` (after) | **26.11** | yes (Hydra channel) |
| `master` | 26.11 | no |

`nixpkgs-unstable` has already crossed to 26.11 *and* stays binary-cached, so it aligns with home-manager `master` without the uncached local rebuilds `master` would trigger.

- `flake.nix`: `nixos-unstable` -> `nixpkgs-unstable`
- `flake.lock`: nixpkgs `64c08a7` (26.05) -> `3109eaae` (26.11pre-git)

## Verification

- `nix eval .#homeConfigurations."nixos@wsl".pkgs.lib.version` -> `26.11pre-git`
- `config.warnings` no longer contains the version mismatch
- `./install.sh --rebuild` builds and activates cleanly (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
