### PR TITLE
:wrench: chore(claude): swap npx context7 MCP for remote HTTP, disable Python hooks

### DIFF
--- a/claude/README.md
+++ b/claude/README.md
@@ -38,7 +38,7 @@ Official plugins from `claude-plugins-official` are **installed automatically** 
 Some popular official plugins from `claude-plugins-official`:
 
 - `frontend-design` - UI/UX design assistance
-- `context7` - Context management
+- `context7` - Up-to-date docs lookup (disabled here — see [Disabled Plugins](#disabled-plugins))
 - `feature-dev` - Feature development workflows
 - `playwright` - Browser automation testing
 - `security-guidance` - Security best practices
@@ -270,6 +270,39 @@ claude plugin uninstall plugin-name@marketplace --scope user
 ```bash
 claude plugin validate ./path/to/marketplace
 ```
+
+## MCP Servers
+
+MCP servers are configured separately from plugins: they live in `~/.claude.json`
+at **user scope** and are managed with the `claude mcp` CLI (not `settings.json`).
+`setup-marketplace.sh` registers them idempotently, so a fresh machine reproduces
+them on the next `home-manager switch`.
+
+### context7 (remote HTTP)
+
+Up-to-date library documentation lookup. We use Context7's **remote** MCP at
+`https://mcp.context7.com/mcp` instead of the official `context7` plugin, which
+bundles a stdio MCP run via `npx -y @upstash/context7-mcp`. That npx server
+targets `context7.com`, which is unreachable from this network (TCP `:443` times
+out), so it hangs. The remote host responds and spawns no local Node process.
+
+- Works keyless at a lower rate limit.
+- For higher limits, `export CONTEXT7_API_KEY=...` before running
+  `./claude/setup-marketplace.sh --update`. The key is sent as a request header
+  and is **never** written to this repo.
+- Tools: `resolve-library-id`, `query-docs` — pre-approved in `settings.json`
+  via `permissions.allow` → `mcp__context7`.
+
+## Disabled Plugins
+
+These official plugins are set to `false` in `settings.json`:
+
+- `context7` — replaced by the remote MCP above (see [MCP Servers](#mcp-servers)).
+- `security-guidance` — its hooks (SessionStart / UserPromptSubmit / PostToolUse /
+  Stop) shell out to Python via `sg-python.sh`, and there is no `python3` in this
+  environment (language runtimes are not installed globally). With no interpreter,
+  every turn printed *"no working Python 3 interpreter found"*. On-demand security
+  review remains available via the built-in `/security-review`.
 
 ## Known Limitations
 

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -9,6 +9,7 @@
       "WebFetch",
       "WebSearch",
       "Skill",
+      "mcp__context7",
       "Bash(ls:*)",
       "Bash(pwd:*)",
       "Bash(which:*)",
@@ -113,13 +114,13 @@
     "claude-md-management@claude-plugins-official": true,
     "ralph-loop@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,
-    "security-guidance@claude-plugins-official": true,
+    "security-guidance@claude-plugins-official": false,
     "claude-code-setup@claude-plugins-official": true,
     "pr-review-toolkit@claude-plugins-official": true,
     "explanatory-output-style@claude-plugins-official": true,
     "playground@claude-plugins-official": true,
     "learning-output-style@claude-plugins-official": true,
-    "context7@claude-plugins-official": true
+    "context7@claude-plugins-official": false
   },
   "effortLevel": "xhigh",
   "showThinkingSummaries": true,

--- a/claude/setup-marketplace.sh
+++ b/claude/setup-marketplace.sh
@@ -27,12 +27,44 @@ PLUGINS=(
   "jj-master@local"
 )
 
+# Remote MCP servers registered at user scope (not bundled as plugins).
+# context7: streamable-HTTP remote MCP. Replaces the npx @upstash/context7-mcp
+# plugin, whose server targets context7.com (unreachable here -> the hangs). The
+# remote host mcp.context7.com responds without spawning a local Node process.
+# Optional: export CONTEXT7_API_KEY before running for higher rate limits.
+CONTEXT7_MCP_URL="https://mcp.context7.com/mcp"
+
 # Check prerequisites
 check_claude() {
   if ! command -v claude &>/dev/null; then
     error "claude CLI not found. Install Claude Code first."
     exit 1
   fi
+}
+
+# Register remote MCP servers (idempotent at user scope)
+setup_mcp() {
+  check_claude
+
+  if claude mcp get context7 &>/dev/null; then
+    info "MCP server already registered: context7"
+    return 0
+  fi
+
+  info "Adding remote MCP server: context7 ($CONTEXT7_MCP_URL)"
+  if [[ -n "${CONTEXT7_API_KEY:-}" ]]; then
+    claude mcp add --transport http --scope user context7 "$CONTEXT7_MCP_URL" \
+      --header "CONTEXT7_API_KEY: ${CONTEXT7_API_KEY}"
+  else
+    claude mcp add --transport http --scope user context7 "$CONTEXT7_MCP_URL"
+  fi
+}
+
+# Remove remote MCP servers
+remove_mcp() {
+  check_claude
+  info "Removing remote MCP server: context7"
+  claude mcp remove context7 2>/dev/null || true
 }
 
 # Install marketplace and plugins
@@ -52,6 +84,8 @@ install() {
     claude plugin install "$plugin" --scope user
   done
 
+  setup_mcp
+
   echo ""
   info "Done! Restart Claude Code to use the new plugins."
 }
@@ -67,6 +101,8 @@ uninstall() {
 
   info "Removing local marketplace..."
   claude plugin marketplace remove local 2>/dev/null || true
+
+  remove_mcp
 
   echo ""
   info "Done! Marketplace and plugins removed."
@@ -85,6 +121,9 @@ update() {
     claude plugin uninstall "$plugin" --scope user 2>/dev/null || true
     claude plugin install "$plugin" --scope user
   done
+
+  remove_mcp
+  setup_mcp
 
   echo ""
   info "Done! Restart Claude Code to pick up changes."


### PR DESCRIPTION
## Why

**context7 was hanging, not just slow.** The official `context7` plugin bundles a
stdio MCP launched with `npx -y @upstash/context7-mcp`. That server talks to
`context7.com`, which is **unreachable from this network** — raw TCP to
`76.76.21.21:443` times out (while `vercel.com` and `mcp.context7.com` respond,
so it's host-specific, not a Vercel-wide block). So every lookup paid the npx
cold-start *and then* stalled on an unreachable host.

**security-guidance spammed Python errors.** Its hooks fire on SessionStart,
UserPromptSubmit, every Edit/Write, every Bash, and Stop — all routed through
`sg-python.sh` → Python. There's no `python3` in this environment and language
runtimes aren't installed globally, so each turn printed
`no working Python 3 interpreter found`.

## What changed (`claude/`)

- **settings.json**
  - `context7@claude-plugins-official` → `false` (kills the npx MCP)
  - `security-guidance@claude-plugins-official` → `false` (kills the Python hooks)
  - `permissions.allow` += `mcp__context7` (frictionless doc lookups)
- **setup-marketplace.sh** — register/remove Context7's **remote HTTP MCP**
  (`https://mcp.context7.com/mcp`) at user scope, idempotently. Runs on every
  Home Manager activation. Honors an optional `CONTEXT7_API_KEY` env var as a
  request header for higher rate limits — **never written to the repo**.
- **README.md** — new *MCP Servers* + *Disabled Plugins* sections.

## Why remote MCP (not a pure web-fetch skill)

`context7.com`'s REST/web surface is unreachable here, so a `WebFetch`/`curl`
skill would hang for the same reason (verified: 4/4 `WebFetch` + local `curl`
timeouts). The only reachable Context7 surface is its **remote MCP host**
`mcp.context7.com` — no npx, no local Node process, keyless init works.

## Verification

- `claude mcp list` → `context7: https://mcp.context7.com/mcp (HTTP) - ✓ Connected`
- `jq -e . settings.json` → valid; plugin flags + allow entry confirmed
- `bash -n setup-marketplace.sh` → clean
- Tools exposed: `resolve-library-id`, `query-docs` (read-only)

## Notes

- Loses only security-guidance's *passive* scanning (already broken). On-demand
  `/security-review` (Python-free) is unaffected.
- Possible follow-up: a small **bash/jq** PostToolUse security-nudge hook in this
  repo if passive scanning is wanted without Python.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
