### PR TITLE
:sparkles: feat(pi): add assistant insight card

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -164,6 +164,63 @@
             '';
           } else { };
         in {
+          pi-assistant-insight-tests = pkgs.runCommand "pi-assistant-insight-tests"
+            {
+              src = self;
+              nativeBuildInputs = [ pkgs.nodejs ];
+            } ''
+            cp -R "$src" source
+            chmod -R u+w source
+            cd source
+            node --test pi/assistant-insight/core.test.ts
+
+            export PI_NODE_MODULES="${pkgs.pi-coding-agent}/lib/node_modules"
+            export PI_ASSISTANT_INSIGHT_CORE="$PWD/pi/assistant-insight/core.ts"
+            node --input-type=module <<'NODE'
+            import assert from "node:assert/strict";
+            import { readFileSync, writeFileSync } from "node:fs";
+            import { tmpdir } from "node:os";
+            import { join } from "node:path";
+
+            const tmpIndex = join(tmpdir(), "assistant-insight-index.ts");
+            const source = readFileSync("pi/assistant-insight/index.ts", "utf8")
+              .replaceAll("@PI_NODE_MODULES@", process.env.PI_NODE_MODULES)
+              .replaceAll("@PI_ASSISTANT_INSIGHT_CORE@", process.env.PI_ASSISTANT_INSIGHT_CORE);
+
+            assert.equal(source.includes("@PI_"), false);
+            writeFileSync(tmpIndex, source);
+
+            const themeModule = await import(
+              "file://" + process.env.PI_NODE_MODULES + "/@earendil-works/pi-coding-agent/dist/modes/interactive/theme/theme.js"
+            );
+            themeModule.initTheme("dark", false);
+
+            const extension = await import("file://" + tmpIndex);
+            extension.default();
+
+            const { AssistantMessageComponent } = await import(
+              "file://" + process.env.PI_NODE_MODULES + "/@earendil-works/pi-coding-agent/dist/modes/interactive/components/assistant-message.js"
+            );
+            const component = new AssistantMessageComponent({
+              role: "assistant",
+              content: [{ type: "text", text: "Useful insight.\n\nRemaining response." }],
+              stopReason: "stop",
+            });
+            const rendered = component.render(100).join("\n");
+
+            assert.equal(component.contentContainer.children.length, 4);
+            assert.equal(component.contentContainer.children[0].constructor.name, "Spacer");
+            assert.equal(component.contentContainer.children[1].constructor.name, "Box");
+            assert.equal(component.contentContainer.children[2].constructor.name, "Spacer");
+            assert.match(rendered, /Insight/);
+            assert.match(rendered, /Useful insight\./);
+            assert.match(rendered, /Remaining response\./);
+            assert.equal(rendered.match(/Useful insight\./g)?.length, 1);
+            NODE
+
+            touch "$out"
+          '';
+
           pi-goal-tests = pkgs.runCommand "pi-goal-tests"
             {
               src = self;

--- a/modules/pi.nix
+++ b/modules/pi.nix
@@ -9,6 +9,11 @@
     [ "${pkgs.pi-coding-agent}/lib/node_modules" ]
     (builtins.readFile ../pi/claude-vim.ts);
   home.file.".pi/agent/extensions/agent-compat.ts".source = ../pi/agent-compat.ts;
+  home.file.".pi/agent/extensions/assistant-insight/index.ts".text = builtins.replaceStrings
+    [ "@PI_NODE_MODULES@" "@PI_ASSISTANT_INSIGHT_CORE@" ]
+    [ "${pkgs.pi-coding-agent}/lib/node_modules" "${../pi/assistant-insight/core.ts}" ]
+    (builtins.readFile ../pi/assistant-insight/index.ts);
+  home.file.".pi/agent/extensions/assistant-insight/core.ts".source = ../pi/assistant-insight/core.ts;
   home.file.".pi/agent/extensions/goal/index.ts".source = ../pi/goal/index.ts;
   home.file.".pi/agent/extensions/goal/core.ts".source = ../pi/goal/core.ts;
   home.file.".pi/agent/extensions/subagents/index.ts".text = builtins.replaceStrings

--- a/pi/assistant-insight/core.test.ts
+++ b/pi/assistant-insight/core.test.ts
@@ -1,0 +1,124 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { patchAssistantMessageComponent, splitAssistantInsightMessage } from "./core.ts";
+
+test("extracts the first assistant paragraph into insight and removes it from TUI display text", () => {
+  const message = {
+    role: "assistant",
+    content: [
+      {
+        type: "text",
+        text: "I found the root cause in the Pi renderer.\n\nThe fix is to patch AssistantMessageComponent.\n\nThis leaves the saved message unchanged.",
+      },
+    ],
+  };
+
+  const result = splitAssistantInsightMessage(message);
+
+  assert.equal(result.insight, "I found the root cause in the Pi renderer.");
+  assert.deepEqual(result.displayMessage.content, [
+    {
+      type: "text",
+      text: "The fix is to patch AssistantMessageComponent.\n\nThis leaves the saved message unchanged.",
+    },
+  ]);
+  assert.equal(message.content[0].text, "I found the root cause in the Pi renderer.\n\nThe fix is to patch AssistantMessageComponent.\n\nThis leaves the saved message unchanged.");
+});
+
+test("removes the first text block when the assistant response is a single paragraph", () => {
+  const message = {
+    role: "assistant",
+    content: [
+      { type: "thinking", thinking: "internal trace" },
+      { type: "text", text: "All set — the TUI card is installed." },
+      { type: "toolCall", name: "read", id: "call-1", input: {} },
+    ],
+  };
+
+  const result = splitAssistantInsightMessage(message);
+
+  assert.equal(result.insight, "All set — the TUI card is installed.");
+  assert.deepEqual(result.displayMessage.content, [
+    { type: "thinking", thinking: "internal trace" },
+    { type: "toolCall", name: "read", id: "call-1", input: {} },
+  ]);
+});
+
+test("skips empty text blocks and leaves messages without text unchanged", () => {
+  const textMessage = {
+    role: "assistant",
+    content: [
+      { type: "text", text: "  \n\n" },
+      { type: "text", text: "First useful paragraph.\n\nMore detail." },
+    ],
+  };
+
+  assert.deepEqual(splitAssistantInsightMessage(textMessage), {
+    insight: "First useful paragraph.",
+    displayMessage: {
+      role: "assistant",
+      content: [
+        { type: "text", text: "  \n\n" },
+        { type: "text", text: "More detail." },
+      ],
+    },
+  });
+
+  const toolOnlyMessage = { role: "assistant", content: [{ type: "toolCall", name: "bash" }] };
+  const toolOnlyResult = splitAssistantInsightMessage(toolOnlyMessage);
+
+  assert.equal(toolOnlyResult.insight, undefined);
+  assert.equal(toolOnlyResult.displayMessage, toolOnlyMessage);
+});
+
+test("patches AssistantMessageComponent to insert one insight card before remaining response text", () => {
+  class FakeSpacer {
+    lines: number;
+
+    constructor(lines: number) {
+      this.lines = lines;
+    }
+  }
+
+  class FakeAssistantMessageComponent {
+    contentContainer = { children: [] as unknown[] };
+    lastMessage?: unknown;
+
+    updateContent(message: any) {
+      this.lastMessage = message;
+      this.contentContainer.children = message.content.length > 0 ? [new FakeSpacer(1), { kind: "markdown", content: message.content }] : [];
+    }
+  }
+
+  assert.equal(
+    patchAssistantMessageComponent(FakeAssistantMessageComponent, {
+      createInsightCard: (insight) => ({ kind: "insight-card", insight }),
+      Spacer: FakeSpacer,
+    }),
+    true,
+  );
+  assert.equal(
+    patchAssistantMessageComponent(FakeAssistantMessageComponent, {
+      createInsightCard: (insight) => ({ kind: "duplicate-card", insight }),
+      Spacer: FakeSpacer,
+    }),
+    false,
+  );
+
+  const originalMessage = {
+    role: "assistant",
+    content: [{ type: "text", text: "Useful insight.\n\nRemaining response." }],
+  };
+  const component = new FakeAssistantMessageComponent();
+
+  component.updateContent(originalMessage);
+
+  assert.equal(component.lastMessage, originalMessage);
+  assert.deepEqual(component.contentContainer.children, [
+    new FakeSpacer(1),
+    { kind: "insight-card", insight: "Useful insight." },
+    new FakeSpacer(1),
+    { kind: "markdown", content: [{ type: "text", text: "Remaining response." }] },
+  ]);
+});

--- a/pi/assistant-insight/core.ts
+++ b/pi/assistant-insight/core.ts
@@ -1,0 +1,102 @@
+type MessageWithContent = {
+  content?: Array<Record<string, any>>;
+};
+
+type ParagraphSplit = {
+  paragraph: string;
+  remainder: string;
+};
+
+type AssistantMessageComponentClass = {
+  prototype?: {
+    updateContent?: (message: any) => void;
+    [key: symbol]: unknown;
+  };
+};
+
+type PatchDeps = {
+  createInsightCard: (insight: string) => unknown;
+  Spacer: new (lines: number) => unknown;
+};
+
+const PATCH_MARK = Symbol.for("dotfiles.pi.assistant-insight.patched");
+
+function splitFirstParagraph(text: string): ParagraphSplit | undefined {
+  const body = text.trimStart();
+  if (!body.trim()) return undefined;
+
+  const separator = /\n[ \t]*\n/.exec(body);
+  if (!separator) {
+    return { paragraph: body.trim(), remainder: "" };
+  }
+
+  const paragraph = body.slice(0, separator.index).trim();
+  if (!paragraph) return undefined;
+
+  return {
+    paragraph,
+    remainder: body.slice(separator.index + separator[0].length).trimStart(),
+  };
+}
+
+export function patchAssistantMessageComponent(AssistantMessageComponent: AssistantMessageComponentClass, deps: PatchDeps): boolean {
+  const proto = AssistantMessageComponent?.prototype;
+  if (!proto || typeof proto.updateContent !== "function" || proto[PATCH_MARK]) return false;
+
+  const originalUpdateContent = proto.updateContent;
+  proto[PATCH_MARK] = true;
+
+  proto.updateContent = function patchedUpdateContent(this: any, message: any): void {
+    const { insight, displayMessage } = splitAssistantInsightMessage(message);
+
+    originalUpdateContent.call(this, displayMessage);
+    this.lastMessage = message;
+
+    if (!insight) return;
+
+    const container = this.contentContainer;
+    if (!container || !Array.isArray(container.children)) return;
+
+    if (!(container.children[0] instanceof deps.Spacer)) {
+      container.children.unshift(new deps.Spacer(1));
+    }
+
+    const insertAt = 1;
+    container.children.splice(insertAt, 0, deps.createInsightCard(insight));
+
+    if (container.children.length > insertAt + 1) {
+      container.children.splice(insertAt + 1, 0, new deps.Spacer(1));
+    }
+  };
+
+  return true;
+}
+
+export function splitAssistantInsightMessage<T extends MessageWithContent>(message: T): {
+  insight?: string;
+  displayMessage: T;
+} {
+  if (!Array.isArray(message.content)) return { displayMessage: message };
+
+  for (let index = 0; index < message.content.length; index++) {
+    const part = message.content[index];
+    if (part?.type !== "text" || typeof part.text !== "string") continue;
+
+    const split = splitFirstParagraph(part.text);
+    if (!split) continue;
+
+    const content = [...message.content];
+    if (split.remainder.trim()) {
+      content[index] = { ...part, text: split.remainder };
+    } else {
+      content.splice(index, 1);
+    }
+
+    return {
+      insight: split.paragraph,
+      displayMessage: { ...message, content } as T,
+    };
+  }
+
+  return { displayMessage: message };
+}

--- a/pi/assistant-insight/index.ts
+++ b/pi/assistant-insight/index.ts
@@ -1,0 +1,40 @@
+/**
+ * Claude Code-like assistant Insight card for pi.
+ *
+ * Loaded globally by Home Manager at ~/.pi/agent/extensions/assistant-insight/index.ts.
+ * This intentionally patches pi's interactive AssistantMessageComponent so the
+ * assistant's first text paragraph is shown as a TUI-only Insight card without
+ * changing the saved assistant message or model context.
+ */
+
+// @ts-nocheck
+// Home Manager replaces @PI_NODE_MODULES@ with pkgs.pi-coding-agent's bundled
+// node_modules path, so this extension does not need globally installed node
+// packages or a project-local npm install.
+import { AssistantMessageComponent } from "@PI_NODE_MODULES@/@earendil-works/pi-coding-agent/dist/modes/interactive/components/assistant-message.js";
+import { getMarkdownTheme, theme } from "@PI_NODE_MODULES@/@earendil-works/pi-coding-agent/dist/modes/interactive/theme/theme.js";
+import { Box, Markdown, Spacer, Text } from "@PI_NODE_MODULES@/@earendil-works/pi-tui/dist/index.js";
+
+import { patchAssistantMessageComponent } from "@PI_ASSISTANT_INSIGHT_CORE@";
+
+function createInsightCard(insight: string) {
+  const box = new Box(1, 1, (text) => theme.bg("customMessageBg", text));
+  const label = theme.fg("customMessageLabel", theme.bold("✻ Insight"));
+
+  box.addChild(new Text(label, 0, 0));
+  box.addChild(new Spacer(1));
+  box.addChild(
+    new Markdown(insight, 0, 0, getMarkdownTheme(), {
+      color: (text) => theme.fg("customMessageText", text),
+    }),
+  );
+
+  return box;
+}
+
+export default function assistantInsight() {
+  patchAssistantMessageComponent(AssistantMessageComponent, {
+    createInsightCard,
+    Spacer,
+  });
+}


### PR DESCRIPTION
## Summary
- Add a Pi assistant-insight extension that renders the first assistant text paragraph as a TUI-only `✻ Insight` card.
- Preserve saved assistant messages/model context by rendering the remaining response from a cloned display message.
- Install the extension through Home Manager and add flake coverage for core logic plus a live `dist` AssistantMessageComponent render smoke test.

## Test Plan
- [x] `node --test $(find pi -name '*.test.ts' | sort)`
- [x] `nix flake check`
- [x] `home-manager switch --flake '.#nixos@wsl'`
- [x] Installed extension live-dist smoke test with `AssistantMessageComponent`
