### PR TITLE
:wrench: chore(nixos): add automatic garbage collection

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -68,5 +68,22 @@
     defaultNetwork.settings.dns_enabled = true;
   };
 
+  # Automatic store garbage collection. On WSL2 the backing ext4.vhdx only ever
+  # grows to its high-water mark and never shrinks on its own, so unbounded
+  # /nix/store growth steadily fills the Windows host disk. A weekly sweep that
+  # drops generations older than 7 days keeps that high-water mark in check.
+  # (Reclaims old NixOS system generations; run `nix-collect-garbage -d` as your
+  # user to also expire standalone home-manager generations.)
+  nix.gc = {
+    automatic = true;
+    dates = "weekly";
+    options = "--delete-older-than 7d";
+  };
+
+  # Deduplicate identical files in /nix/store via hardlinks. Applied inline as
+  # new paths are added; run `nix store optimise` once to dedupe what's already
+  # there. This is what actually shrinks the live store between GC sweeps.
+  nix.settings.auto-optimise-store = true;
+
   system.stateVersion = "25.05";
 }


### PR DESCRIPTION
## Why

On WSL2 the backing `ext4.vhdx` only ever grows to its high-water mark and never shrinks on its own. With no automatic garbage collection, `/nix/store` growth from repeated `home-manager`/`nixos-rebuild` churn steadily inflates the vhdx until it fills the Windows host disk.

## What

Adds to the system config (`nixos/configuration.nix`):

- `nix.gc` — weekly sweep, `--delete-older-than 7d`, reclaiming old NixOS system generations.
- `nix.settings.auto-optimise-store = true` — hardlink-dedupes identical store files inline as paths are added.

## Verification

- `nix-instantiate --parse nixos/configuration.nix` → parse OK.
- Full eval `nix-instantiate '<nixpkgs/nixos>' -A system -I nixos-config=…` → produced `nixos-system-nixos-25.05….drv` (options valid, config builds).

## Apply (manual, on the host)

\`\`\`
sudo cp nixos/configuration.nix /etc/nixos/configuration.nix
sudo nixos-rebuild switch
\`\`\`

> Note: this \`cp\` makes the repo config authoritative, which also brings in the repo's podman / \`wsl.interop.register\` settings if the live \`/etc/nixos\` is behind.

One-time reclamation + vhdx compaction is documented separately (not part of this PR).