### PR TITLE
:sparkles: feat(headroom): add headroom-ai MCP server for Claude Code & Pi

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -50,6 +50,27 @@
         "type": "github"
       }
     },
+    "headroom": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2",
+        "pyproject-build-systems": "pyproject-build-systems",
+        "pyproject-nix": "pyproject-nix",
+        "uv2nix": "uv2nix"
+      },
+      "locked": {
+        "lastModified": 1780396287,
+        "narHash": "sha256-w4U1jzrklqzvzYyLxnCypxbxJivbDJrWv6+zqNTKgPU=",
+        "owner": "LITl-l",
+        "repo": "headroom-overlay",
+        "rev": "7676f3ef19d1b4c4a4fef8e2048dcfd99b50f099",
+        "type": "github"
+      },
+      "original": {
+        "owner": "LITl-l",
+        "repo": "headroom-overlay",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -88,6 +109,22 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1780336545,
+        "narHash": "sha256-vhVhuXzFrIOfcssC/9hDHx7MHzDKjF3keHuREOQqQiQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4df1b885d76a54e1aa1a318f8d16fd6005b6401f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 1780246643,
         "narHash": "sha256-4T1KWX7xWGQMs9hNZ24IOY3aYOi8D6+5WtkNRBSttB8=",
         "owner": "nixos",
@@ -102,7 +139,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1773646010,
         "narHash": "sha256-iYrs97hS7p5u4lQzuNWzuALGIOdkPXvjz7bviiBjUu8=",
@@ -120,7 +157,7 @@
     },
     "pi": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_4",
         "systems": "systems"
       },
       "locked": {
@@ -137,13 +174,64 @@
         "type": "github"
       }
     },
+    "pyproject-build-systems": {
+      "inputs": {
+        "nixpkgs": [
+          "headroom",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "headroom",
+          "pyproject-nix"
+        ],
+        "uv2nix": [
+          "headroom",
+          "uv2nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779676664,
+        "narHash": "sha256-MbXylBTkWqVm8/VYjoULtMoVRgWBN1gSHbeRKsOsPlU=",
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "rev": "7bff980f37fc24e09dbc986643719900c139bf12",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "headroom",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778901413,
+        "narHash": "sha256-GSKXTAnFqRAMlZkJrIPcQMYf+lpMr66K3i60mB9STvc=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "a228447c3e179d477c1b6246ef3efa8cfe3c469a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "claude-code": "claude-code",
         "fish-plugin-fzf": "fish-plugin-fzf",
         "fish-plugin-z": "fish-plugin-z",
+        "headroom": "headroom",
         "home-manager": "home-manager",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_3",
         "pi": "pi"
       }
     },
@@ -159,6 +247,31 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "uv2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "headroom",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "headroom",
+          "pyproject-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780358675,
+        "narHash": "sha256-n4jX4svZwmoWpzhz3If9wkvEYKv3WuDvprE8vi57MRY=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "3a557a9e78cc5b11bc9a610f27da4bdd5599edfe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,11 @@
     pi = {
       url = "github:lukasl-dev/pi.nix";
     };
+
+    # headroom context-compression MCP server (native binary via Cachix)
+    headroom = {
+      url = "github:LITl-l/headroom-overlay";
+    };
   };
 
   outputs = { self, nixpkgs, home-manager, ... }@inputs:
@@ -49,6 +54,10 @@
         overlays = [
           inputs.claude-code.overlays.default
           inputs.pi.overlays.default
+        ] ++ nixpkgs.lib.optionals (system == "x86_64-linux") [
+          # headroom-overlay only publishes x86_64-linux; gate it so the
+          # darwin/aarch64 configs (and `nix flake check`) still evaluate.
+          inputs.headroom.overlays.default
         ];
       });
     in

--- a/home.nix
+++ b/home.nix
@@ -68,6 +68,11 @@ in
     nixpkgs-fmt # Nix formatter
     nil # Nix LSP
     nix-manager # Custom nix-manager command
+  ] ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+    # headroom-ai context-compression CLI + MCP server (via LITl-l/headroom-overlay).
+    # Linux-guarded: the overlay only publishes x86_64-linux. pkgs.headroom is
+    # fully qualified because this append is outside the `with pkgs;` scope above.
+    pkgs.headroom
   ];
 
   # Environment variables
@@ -100,6 +105,9 @@ in
       accept-flake-config = true
       extra-substituters = https://ryoppippi.cachix.org https://pi.cachix.org
       extra-trusted-public-keys = ryoppippi.cachix.org-1:b2LbtWNvJeL/qb1B6TYOMK+apaCps4SCbzlPRfSQIms= pi.cachix.org-1:lGeoGJaZ5ZDabuRzkcD5EBTNnDM4HJ1vqeOxlWk1Flk=
+      # headroom-overlay cachix cache (deferred): once the cache + public key exist,
+      # append " https://headroom-overlay.cachix.org" to extra-substituters above and
+      # " headroom-overlay.cachix.org-1:<KEY>" to extra-trusted-public-keys above.
       !include ${config.home.homeDirectory}/.config/nix/nix.local.conf
     '';
   };

--- a/modules/claude-code.nix
+++ b/modules/claude-code.nix
@@ -19,4 +19,19 @@ in
       "${dotfilesClaudePath}/setup-marketplace.sh" --update 2>/dev/null || true
     fi
   '';
+
+  # Register headroom-ai's stdio MCP server with Claude Code at user scope. MCP
+  # servers live in the stateful ~/.claude.json, so we delegate the file
+  # location/format to the `claude` CLI rather than managing it declaratively.
+  #
+  # `claude` is invoked by absolute store path because the new generation's bin/
+  # is not on PATH during activation; `headroom` is registered as a *bare*
+  # command (resolved from PATH when Claude launches it), which keeps the entry
+  # stable across headroom updates. Idempotent: `claude mcp get` exits non-zero
+  # when absent, so we add at most once; safe to re-run on every switch.
+  home.activation.registerHeadroomMcp = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    if ! ${pkgs.claude-code}/bin/claude mcp get headroom >/dev/null 2>&1; then
+      ${pkgs.claude-code}/bin/claude mcp add headroom -s user -- headroom mcp serve >/dev/null 2>&1 || true
+    fi
+  '';
 }

--- a/modules/pi.nix
+++ b/modules/pi.nix
@@ -23,6 +23,22 @@
 
   home.file.".pi/agent/themes/claude-code.json".source = ../pi/claude-code-theme.json;
 
+  # Register headroom-ai's context-compression MCP server (stdio transport). Pi
+  # reads ~/.pi/agent/mcp.json. lifecycle "lazy" means Pi only spawns the server
+  # when a headroom_* tool is actually invoked. headroom is on PATH on Linux via
+  # home.packages (LITl-l/headroom-overlay).
+  home.file.".pi/agent/mcp.json".text = ''
+    {
+      "mcpServers": {
+        "headroom": {
+          "command": "headroom",
+          "args": ["mcp", "serve"],
+          "lifecycle": "lazy"
+        }
+      }
+    }
+  '';
+
   # Keep existing pi settings/auth intact, but select the Claude Code-like theme.
   home.activation.setPiClaudeCodeTheme = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     settings="$HOME/.pi/agent/settings.json"


### PR DESCRIPTION
## What

Adds [`headroom-ai`](https://github.com/chopratejas/headroom) (a context-compression layer for AI agents) and registers its stdio MCP server (`headroom mcp serve`) for both **Claude Code** and **Pi**.

Packaging is delivered through a new public overlay repo — **https://github.com/LITl-l/headroom-overlay** — built with uv2nix from PyPI wheels (pinned via `uv.lock`), mirroring how `claude-code` and `pi` are consumed.

## Changes

- **flake.nix** — add `headroom` input (`github:LITl-l/headroom-overlay`) and its overlay, gated to `x86_64-linux` (the overlay only publishes that system, so darwin/aarch64 eval stays clean).
- **home.nix** — install `pkgs.headroom` (guarded to Linux); leave an in-place TODO for the Cachix substituter+key (deferred — see Follow-ups).
- **modules/pi.nix** — declarative `~/.pi/agent/mcp.json` registering headroom (`lifecycle: "lazy"`).
- **modules/claude-code.nix** — idempotent activation running `claude mcp add headroom -s user -- headroom mcp serve` (invokes `claude` by absolute store path; registers `headroom` as a bare PATH-resolved command).

## Why fastapi

headroom's CLI eagerly imports its `proxy` subcommand at startup (→ `fastapi`), so the `headroom` binary can't start with only `[mcp]`. `fastapi` is the *only* extra third-party module in that eager-import closure, so the overlay pins `headroom-ai[mcp]` + `fastapi` (77 wheel packages, no Rust compile) rather than the heavy `[proxy]` extra.

## Verification

- Overlay: `nix flake check` green; CI green (build + smoke test; Cachix push auto-skips with no token).
- Dotfiles: `nix flake check`/eval green for both `nixos@wsl` and `user@darwin` (guard holds).
- `home-manager switch` applied successfully; `headroom 0.22.4` on PATH.
- `claude mcp get headroom` → **✓ Connected** (`headroom mcp serve`); re-switch is idempotent (single entry).
- `~/.pi/agent/mcp.json` present with the headroom entry.

## Follow-ups (deferred)

- **Cachix:** create the `headroom-overlay` cache, add `CACHIX_AUTH_TOKEN` as an Actions secret on the overlay repo, then (a) add the `nixConfig` substituter+public-key back to the overlay flake and (b) append the cache + key to `home.nix`'s `nix.conf` (TODO comment marks the spot).