### PR TITLE
:arrow_up: chore(flake): re-lock inputs to latest (nixpkgs, home-manager, pi, claude-code)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1780258872,
-        "narHash": "sha256-VHzkE0xzvMKKI+iHBdqPWNFSPIpr+5QRwQsLjMfwIKE=",
+        "lastModified": 1780424083,
+        "narHash": "sha256-rLZlfCYiYsHZVaJSB9/gptH2wVrlCRoNh8NBWi4flnU=",
         "owner": "ryoppippi",
         "repo": "claude-code-overlay",
-        "rev": "7c80c9aa86a9ed59f5902d0d3a00a2c1d9df910c",
+        "rev": "0c2e95452c12f9df8e7f1978e8a348c71b22758c",
         "type": "github"
       },
       "original": {
@@ -78,11 +78,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780099287,
-        "narHash": "sha256-efIPwVGtIWIjWcznhaop6XN6HxnOL8800hF6CBNvlqQ=",
+        "lastModified": 1780408569,
+        "narHash": "sha256-s7Tv6FUQThRAvW8En8XVC6HMb0uiikzVccCcCo9u/Bg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7d8127d308c3fb9664f7e643eec944be74ebb37d",
+        "rev": "f384af1bec6423a0d4ba1855917ab948f64e5808",
         "type": "github"
       },
       "original": {
@@ -125,11 +125,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1780246643,
-        "narHash": "sha256-4T1KWX7xWGQMs9hNZ24IOY3aYOi8D6+5WtkNRBSttB8=",
+        "lastModified": 1780336545,
+        "narHash": "sha256-vhVhuXzFrIOfcssC/9hDHx7MHzDKjF3keHuREOQqQiQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3109eaae18e09d0b8aef23dc2579e7d94b8d4b4e",
+        "rev": "4df1b885d76a54e1aa1a318f8d16fd6005b6401f",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1780306633,
-        "narHash": "sha256-f6263HSQ4tdmPYcRpIfH3oFxiigBwcXh7I78rXmzwGU=",
+        "lastModified": 1780390085,
+        "narHash": "sha256-QxqhqenhltMfpvRBE3qJ+hic3wqGVNM7cCzHNV+thms=",
         "owner": "lukasl-dev",
         "repo": "pi.nix",
-        "rev": "184761dcc76756d3834acb576b9f3229d5afd084",
+        "rev": "36f07522adfbe92d0ebe02cb0082e3989a2870c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Re-lock all flake inputs to their latest revisions.

| Input | → revision | date |
|-------|-----------|------|
| `nixpkgs` | `4df1b885` (nixpkgs-unstable) | 2026-06-01 |
| `home-manager` | `f384af1b` | 2026-06-02 |
| `pi` | `36f07522` | 2026-06-02 |
| `claude-code` | `0c2e9545` | 2026-06-02 |

## Why

A local `flake.lock` edit was stuck in a `git stash` and collided with #167 on pop, leaving stash conflict markers in the file. Rather than hand-merge a generated lockfile (which risks mismatched `rev`/`narHash` between the `nixpkgs_2`/`nixpkgs_3` nodes), the lock was restored clean from `main` and regenerated atomically via `nix flake update`.

## Verification

- `flake.lock` contains no conflict markers
- `nix flake check` passes (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)