### PR TITLE
:lock: fix(headroom): disable on-by-default telemetry beacon

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -83,6 +83,16 @@ in
     LESS = "-R";
     BROWSER = "xdg-open";
 
+    # Opt out of headroom-ai's on-by-default telemetry. Its TelemetryBeacon
+    # (site-packages/headroom/telemetry/beacon.py) otherwise POSTs anonymous
+    # aggregate stats — plus a SHA256(hostname) machine fingerprint — to a
+    # hardcoded Supabase endpoint every 5 minutes. This is headroom's documented
+    # kill-switch; collector.py honours it too (gates the /v1/telemetry report).
+    # Set at session scope so the `headroom` CLI *and* the MCP servers (which
+    # inherit this env) are covered; also baked into each MCP registration as
+    # defense-in-depth (see modules/claude-code.nix and modules/pi.nix).
+    HEADROOM_TELEMETRY = "off";
+
     # XDG directories
     XDG_CONFIG_HOME = "${config.home.homeDirectory}/.config";
     XDG_DATA_HOME = "${config.home.homeDirectory}/.local/share";

--- a/modules/claude-code.nix
+++ b/modules/claude-code.nix
@@ -27,11 +27,18 @@ in
   # `claude` is invoked by absolute store path because the new generation's bin/
   # is not on PATH during activation; `headroom` is registered as a *bare*
   # command (resolved from PATH when Claude launches it), which keeps the entry
-  # stable across headroom updates. Idempotent: `claude mcp get` exits non-zero
-  # when absent, so we add at most once; safe to re-run on every switch.
+  # stable across headroom updates.
+  #
+  # HEADROOM_TELEMETRY=off is baked into the registration to disable headroom's
+  # on-by-default Supabase telemetry beacon for this MCP server (it also inherits
+  # the session var from home.nix; this is belt-and-suspenders). The guard greps
+  # the entry's Environment for HEADROOM_TELEMETRY so an existing env-less
+  # registration (added before this change) is reconciled exactly once: when the
+  # var is absent we remove + re-add with it; when already present we no-op.
   home.activation.registerHeadroomMcp = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    if ! ${pkgs.claude-code}/bin/claude mcp get headroom >/dev/null 2>&1; then
-      ${pkgs.claude-code}/bin/claude mcp add headroom -s user -- headroom mcp serve >/dev/null 2>&1 || true
+    if ! ${pkgs.claude-code}/bin/claude mcp get headroom 2>/dev/null | grep -q HEADROOM_TELEMETRY; then
+      ${pkgs.claude-code}/bin/claude mcp remove headroom -s user >/dev/null 2>&1 || true
+      ${pkgs.claude-code}/bin/claude mcp add headroom -s user -e HEADROOM_TELEMETRY=off -- headroom mcp serve >/dev/null 2>&1 || true
     fi
   '';
 }

--- a/modules/pi.nix
+++ b/modules/pi.nix
@@ -32,12 +32,17 @@
   # reads ~/.pi/agent/mcp.json. lifecycle "lazy" means Pi only spawns the server
   # when a headroom_* tool is actually invoked. headroom is on PATH on Linux via
   # home.packages (LITl-l/headroom-overlay).
+  #
+  # env HEADROOM_TELEMETRY=off disables headroom's on-by-default Supabase
+  # telemetry beacon for this server regardless of the inherited environment
+  # (mirrors the session var in home.nix and the Claude registration).
   home.file.".pi/agent/mcp.json".text = ''
     {
       "mcpServers": {
         "headroom": {
           "command": "headroom",
           "args": ["mcp", "serve"],
+          "env": { "HEADROOM_TELEMETRY": "off" },
           "lifecycle": "lazy"
         }
       }


### PR DESCRIPTION
## Problem

headroom-ai ships an **on-by-default** telemetry beacon. `telemetry/beacon.py`'s `TelemetryBeacon` POSTs anonymous aggregate stats — token counts, compression ratios, cache hit rates, `models_used`, latency, **plus a `SHA256(hostname)` machine fingerprint** — to a hardcoded Supabase endpoint (`https://dtlllcsudcoasebbamcq.supabase.co/rest/v1/proxy_telemetry_v2`) every 5 minutes. The anon key is deliberately split across source lines "to avoid secret-scanner false positives."

`is_telemetry_enabled()` defaults to `on`; the data-flywheel `TelemetryCollector` (reached from the MCP `headroom_retrieve` tool via `compression_store.py`) honours the same gate.

Other external paths (`reporter.py` → `app.headroomlabs.ai`, litellm cloud, Langfuse, OTLP) are all opt-in and dormant — they require license keys / `HEADROOM_*` flags we don't set.

## Fix

Set `HEADROOM_TELEMETRY=off` (headroom's documented kill-switch) declaratively in three layers:

1. **`home.nix`** — `home.sessionVariables`, covering the `headroom` CLI and any MCP server that inherits the session env.
2. **`modules/claude-code.nix`** — baked into the Claude Code MCP registration via `-e`, with a one-time reconcile (`grep` the entry's Environment) so the pre-existing env-less registration is rewritten exactly once.
3. **`modules/pi.nix`** — `env` block in Pi's managed `mcp.json`.

Defense-in-depth: the per-registration env covers MCP servers spawned by already-running agents that predate the session-var change.

## Verification

- `home-manager switch --flake .#nixos@wsl` succeeds; `registerHeadroomMcp` reconcile ran.
- `claude mcp get headroom` → `Environment: HEADROOM_TELEMETRY=off`
- `~/.pi/agent/mcp.json` → `"env": { "HEADROOM_TELEMETRY": "off" }`
- Fresh fish login shell → `HEADROOM_TELEMETRY=off`
- Functional: `is_telemetry_enabled()` returns `True` by default, `False` with the env set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)