### PR TITLE
:sparkles: feat(pi): add auto model router

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -154,25 +154,27 @@
       checks = forAllSystems (system:
         let
           pkgs = nixpkgsFor.${system};
-          linuxChecks = if system == "x86_64-linux" then {
-            nvim-config-tests = pkgs.runCommand "nvim-config-tests"
-              {
-                src = self;
-                nativeBuildInputs = [ self.homeConfigurations."nixos@wsl".config.programs.neovim.finalPackage ];
-              } ''
-              cp -R "$src" source
-              chmod -R u+w source
-              cd source
-              export XDG_CONFIG_HOME="$PWD"
-              export XDG_DATA_HOME="$TMPDIR/data"
-              export XDG_STATE_HOME="$TMPDIR/state"
-              export XDG_CACHE_HOME="$TMPDIR/cache"
-              nvim --headless +'luafile nvim/tests/leader_e_minifiles.lua' +'qa!'
-              nvim --headless nvim/init.lua +'lua assert(vim.fn.exists(":LspServers") == 2, "LspServers command missing"); local cfg = vim.lsp.config.lua_ls; assert(cfg and type(cfg.cmd) == "table" and #cfg.cmd > 0, "lua_ls cmd missing"); assert(vim.fn.maparg("<leader>l", "n") == "", "<leader>l maps to missing Lazy command")' +'qa!'
-              touch "$out"
-            '';
-          } else { };
-        in {
+          linuxChecks =
+            if system == "x86_64-linux" then {
+              nvim-config-tests = pkgs.runCommand "nvim-config-tests"
+                {
+                  src = self;
+                  nativeBuildInputs = [ self.homeConfigurations."nixos@wsl".config.programs.neovim.finalPackage ];
+                } ''
+                cp -R "$src" source
+                chmod -R u+w source
+                cd source
+                export XDG_CONFIG_HOME="$PWD"
+                export XDG_DATA_HOME="$TMPDIR/data"
+                export XDG_STATE_HOME="$TMPDIR/state"
+                export XDG_CACHE_HOME="$TMPDIR/cache"
+                nvim --headless +'luafile nvim/tests/leader_e_minifiles.lua' +'qa!'
+                nvim --headless nvim/init.lua +'lua assert(vim.fn.exists(":LspServers") == 2, "LspServers command missing"); local cfg = vim.lsp.config.lua_ls; assert(cfg and type(cfg.cmd) == "table" and #cfg.cmd > 0, "lua_ls cmd missing"); assert(vim.fn.maparg("<leader>l", "n") == "", "<leader>l maps to missing Lazy command")' +'qa!'
+                touch "$out"
+              '';
+            } else { };
+        in
+        {
           pi-assistant-insight-tests = pkgs.runCommand "pi-assistant-insight-tests"
             {
               src = self;
@@ -239,6 +241,18 @@
             chmod -R u+w source
             cd source
             node --test pi/goal/core.test.ts pi/goal/index.test.ts
+            touch "$out"
+          '';
+
+          pi-auto-model-router-tests = pkgs.runCommand "pi-auto-model-router-tests"
+            {
+              src = self;
+              nativeBuildInputs = [ pkgs.nodejs ];
+            } ''
+            cp -R "$src" source
+            chmod -R u+w source
+            cd source
+            node --test pi/auto-model-router/core.test.ts pi/auto-model-router/index.test.ts
             touch "$out"
           '';
 

--- a/modules/pi.nix
+++ b/modules/pi.nix
@@ -16,6 +16,8 @@
   home.file.".pi/agent/extensions/assistant-insight/core.ts".source = ../pi/assistant-insight/core.ts;
   home.file.".pi/agent/extensions/goal/index.ts".source = ../pi/goal/index.ts;
   home.file.".pi/agent/extensions/goal/core.ts".source = ../pi/goal/core.ts;
+  home.file.".pi/agent/extensions/auto-model-router/index.ts".source = ../pi/auto-model-router/index.ts;
+  home.file.".pi/agent/extensions/auto-model-router/core.ts".source = ../pi/auto-model-router/core.ts;
   home.file.".pi/agent/extensions/subagents/index.ts".text = builtins.replaceStrings
     [ "@PI_NODE_MODULES@" "@PI_SUBAGENTS_CORE@" ]
     [ "${pkgs.pi-coding-agent}/lib/node_modules" "${../pi/subagents/core.ts}" ]

--- a/pi/auto-model-router/core.test.ts
+++ b/pi/auto-model-router/core.test.ts
@@ -1,0 +1,142 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  AUTO_MODEL_ROUTER_ENTRY_TYPE,
+  DEFAULT_ROUTER_CONFIG,
+  buildRouterStatus,
+  decideRoute,
+  mergeRouterConfig,
+  parseRouterCommand,
+  reconstructRouterState,
+  resolveEffectiveConfig,
+  truncateSingleLine,
+} from "./core.ts";
+
+test("routes planning, architecture, debugging, and large refactor prompts to the strong profile", () => {
+  for (const prompt of [
+    "Create a complex planning document for this migration",
+    "Debug the root cause of this flaky integration test",
+    "Do a large refactor across the auth module",
+    "Audit this for security and performance issues",
+  ]) {
+    const decision = decideRoute(prompt, DEFAULT_ROUTER_CONFIG, { mode: "auto" });
+
+    assert.equal(decision?.profile, "strong", prompt);
+    assert.equal(decision?.mode, "auto");
+    assert.match(decision?.reason ?? "", /matched/i);
+  }
+});
+
+test("uses the fast default profile for simple implementation prompts", () => {
+  const decision = decideRoute("Implement this small change following the existing docs", DEFAULT_ROUTER_CONFIG, {
+    mode: "auto",
+  });
+
+  assert.equal(decision?.profile, "fast");
+  assert.equal(decision?.reason, "default profile");
+});
+
+test("does not route when off or locked, and routes forced profiles explicitly", () => {
+  assert.equal(decideRoute("plan a rewrite", DEFAULT_ROUTER_CONFIG, { mode: "off" }), undefined);
+  assert.equal(decideRoute("plan a rewrite", DEFAULT_ROUTER_CONFIG, { mode: "locked" }), undefined);
+
+  const forced = decideRoute("plan a rewrite", DEFAULT_ROUTER_CONFIG, { mode: "force", forcedProfile: "fast" });
+  assert.deepEqual(forced, {
+    profile: "fast",
+    reason: "forced profile",
+    mode: "force",
+  });
+});
+
+test("merges project config over global config without dropping unspecified profiles", () => {
+  const merged = mergeRouterConfig(DEFAULT_ROUTER_CONFIG, {
+    defaultProfile: "cheap",
+    notifyOnRoute: false,
+    profiles: {
+      cheap: { provider: "openai", model: "gpt-cheap", thinkingLevel: "low" },
+      strong: { thinkingLevel: "xhigh" },
+    },
+    rules: [{ profile: "cheap", patterns: ["cheap"], reason: "cheap keyword" }],
+  });
+
+  assert.equal(merged.defaultProfile, "cheap");
+  assert.equal(merged.notifyOnRoute, false);
+  assert.equal(merged.profiles.fast.model, "gpt-5.3-codex-spark");
+  assert.deepEqual(merged.profiles.cheap, { provider: "openai", model: "gpt-cheap", thinkingLevel: "low" });
+  assert.equal(merged.profiles.strong.provider, "openai-codex");
+  assert.equal(merged.profiles.strong.model, "gpt-5.5");
+  assert.equal(merged.profiles.strong.thinkingLevel, "xhigh");
+  assert.deepEqual(merged.rules, [{ profile: "cheap", patterns: ["cheap"], reason: "cheap keyword" }]);
+});
+
+test("resolves session profile overrides into the effective config", () => {
+  const effective = resolveEffectiveConfig(DEFAULT_ROUTER_CONFIG, {
+    mode: "auto",
+    profileOverrides: {
+      fast: { provider: "anthropic", model: "claude-fast", thinkingLevel: "medium" },
+    },
+  });
+
+  assert.equal(effective.profiles.fast.provider, "anthropic");
+  assert.equal(effective.profiles.fast.model, "claude-fast");
+  assert.equal(effective.profiles.fast.thinkingLevel, "medium");
+  assert.equal(effective.profiles.strong.model, "gpt-5.5");
+});
+
+test("parses router slash-command arguments", () => {
+  assert.deepEqual(parseRouterCommand(""), { action: "show" });
+  assert.deepEqual(parseRouterCommand("status"), { action: "status" });
+  assert.deepEqual(parseRouterCommand("auto"), { action: "mode", mode: "auto" });
+  assert.deepEqual(parseRouterCommand("unlock"), { action: "mode", mode: "auto" });
+  assert.deepEqual(parseRouterCommand("off"), { action: "mode", mode: "off" });
+  assert.deepEqual(parseRouterCommand("lock"), { action: "mode", mode: "locked" });
+  assert.deepEqual(parseRouterCommand("strong"), { action: "force", profile: "strong" });
+  assert.deepEqual(parseRouterCommand("profile fast"), { action: "force", profile: "fast" });
+  assert.deepEqual(parseRouterCommand("set fast current"), { action: "set-current", profile: "fast" });
+  assert.deepEqual(parseRouterCommand("reload"), { action: "reload" });
+  assert.deepEqual(parseRouterCommand("config"), { action: "config" });
+  assert.deepEqual(parseRouterCommand("help"), { action: "help" });
+});
+
+test("reconstructs latest router state from session entries", () => {
+  const entries = [
+    { type: "custom", customType: AUTO_MODEL_ROUTER_ENTRY_TYPE, data: { mode: "force", forcedProfile: "strong" } },
+    { type: "message", message: { role: "user" } },
+    {
+      type: "custom",
+      customType: AUTO_MODEL_ROUTER_ENTRY_TYPE,
+      data: {
+        mode: "auto",
+        profileOverrides: {
+          fast: { provider: "openai", model: "gpt-fast", thinkingLevel: "low" },
+        },
+      },
+    },
+  ];
+
+  assert.deepEqual(reconstructRouterState(entries, DEFAULT_ROUTER_CONFIG), {
+    mode: "auto",
+    profileOverrides: {
+      fast: { provider: "openai", model: "gpt-fast", thinkingLevel: "low" },
+    },
+  });
+});
+
+test("builds compact status text with route rationale", () => {
+  const status = buildRouterStatus(
+    { mode: "auto", lastDecision: { mode: "auto", profile: "strong", reason: "matched complex", matchedPattern: "complex" } },
+    DEFAULT_ROUTER_CONFIG,
+    80,
+  );
+
+  assert.equal(status, "router: auto→strong — matched complex");
+  assert.equal(buildRouterStatus({ mode: "off" }, DEFAULT_ROUTER_CONFIG), "router: off");
+  assert.equal(buildRouterStatus({ mode: "locked" }, DEFAULT_ROUTER_CONFIG), "router: locked");
+  assert.equal(buildRouterStatus({ mode: "force", forcedProfile: "fast" }, DEFAULT_ROUTER_CONFIG), "router: force→fast");
+});
+
+test("truncates status text on one line", () => {
+  assert.equal(truncateSingleLine("one\n two\tthree", 20), "one two three");
+  assert.equal(truncateSingleLine("1234567890", 6), "12345…");
+});

--- a/pi/auto-model-router/core.ts
+++ b/pi/auto-model-router/core.ts
@@ -1,0 +1,381 @@
+export const AUTO_MODEL_ROUTER_ENTRY_TYPE = "auto_model_router";
+
+export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+export type RouterMode = "auto" | "off" | "locked" | "force";
+
+export interface RouterProfile {
+  provider?: string;
+  model?: string;
+  thinkingLevel?: ThinkingLevel;
+  description?: string;
+}
+
+export interface RouterRule {
+  profile: string;
+  patterns: string[];
+  reason?: string;
+}
+
+export interface RouterConfig {
+  enabled: boolean;
+  defaultProfile: string;
+  lockOnManualModelChange: boolean;
+  notifyOnRoute: boolean;
+  profiles: Record<string, RouterProfile>;
+  rules: RouterRule[];
+}
+
+export interface RouteDecision {
+  profile: string;
+  reason: string;
+  mode: RouterMode;
+  matchedPattern?: string;
+}
+
+export interface RouterState {
+  mode: RouterMode;
+  forcedProfile?: string;
+  profileOverrides?: Record<string, RouterProfile>;
+  lastDecision?: RouteDecision;
+}
+
+export type RouterCommand =
+  | { action: "show" }
+  | { action: "status" }
+  | { action: "mode"; mode: Exclude<RouterMode, "force"> }
+  | { action: "force"; profile: string }
+  | { action: "set-current"; profile: string }
+  | { action: "reload" }
+  | { action: "config" }
+  | { action: "help" };
+
+export const DEFAULT_ROUTER_CONFIG: RouterConfig = {
+  enabled: true,
+  defaultProfile: "fast",
+  lockOnManualModelChange: true,
+  notifyOnRoute: true,
+  profiles: {
+    fast: {
+      provider: "openai-codex",
+      model: "gpt-5.3-codex-spark",
+      thinkingLevel: "minimal",
+      description: "Fast model for simple edits and implementation from existing instructions.",
+    },
+    strong: {
+      provider: "openai-codex",
+      model: "gpt-5.5",
+      thinkingLevel: "high",
+      description: "Frontier model for planning, architecture, debugging, audits, and large refactors.",
+    },
+  },
+  rules: [
+    {
+      profile: "strong",
+      reason: "planning, architecture, or design keyword",
+      patterns: ["\\b(plan|planning|architect|architecture|design|strategy|spec|proposal)\\b"],
+    },
+    {
+      profile: "strong",
+      reason: "complex refactor, debugging, audit, migration, or performance keyword",
+      patterns: [
+        "\\b(refactor|refactoring|rewrite|redesign|migration|migrate|large|complex|hard|deep|debug|investigate|diagnose|audit|security|performance|perf)\\b",
+        "\\broot\\s+cause\\b",
+        "\\bmulti[- ]?file\\b",
+        "\\bcross[- ]?cutting\\b",
+        "\\bsystem[- ]?wide\\b",
+      ],
+    },
+  ],
+};
+
+export function createDefaultRouterState(config: RouterConfig): RouterState {
+  return { mode: config.enabled ? "auto" : "off" };
+}
+
+export function decideRoute(prompt: string, config: RouterConfig, state: RouterState): RouteDecision | undefined {
+  if (state.mode === "off" || state.mode === "locked") return undefined;
+
+  if (state.mode === "force") {
+    const profile = state.forcedProfile;
+    if (!profile || !config.profiles[profile]) return undefined;
+    return { profile, reason: "forced profile", mode: "force" };
+  }
+
+  const normalizedPrompt = prompt.trim();
+  for (const rule of config.rules) {
+    if (!config.profiles[rule.profile]) continue;
+
+    for (const pattern of rule.patterns) {
+      if (matchesPattern(normalizedPrompt, pattern)) {
+        return {
+          profile: rule.profile,
+          reason: `matched ${rule.reason ?? pattern}`,
+          matchedPattern: pattern,
+          mode: "auto",
+        };
+      }
+    }
+  }
+
+  if (!config.profiles[config.defaultProfile]) return undefined;
+  return { profile: config.defaultProfile, reason: "default profile", mode: "auto" };
+}
+
+export function parseRouterCommand(args: string): RouterCommand {
+  const normalized = args.trim().replace(/\s+/g, " ").toLowerCase();
+  if (!normalized) return { action: "show" };
+
+  const tokens = normalized.split(" ");
+  const [first, second, third] = tokens;
+
+  if (first === "status") return { action: "status" };
+  if (first === "help" || first === "?") return { action: "help" };
+  if (first === "reload") return { action: "reload" };
+  if (first === "config" || first === "paths") return { action: "config" };
+  if (first === "auto" || first === "on" || first === "enable" || first === "unlock") return { action: "mode", mode: "auto" };
+  if (first === "off" || first === "disable") return { action: "mode", mode: "off" };
+  if (first === "lock" || first === "locked" || first === "manual") return { action: "mode", mode: "locked" };
+
+  if ((first === "profile" || first === "force" || first === "use") && second) {
+    return { action: "force", profile: second };
+  }
+
+  if (first === "set" && second && third === "current") {
+    return { action: "set-current", profile: second };
+  }
+
+  if (tokens.length === 1) return { action: "force", profile: first };
+  return { action: "help" };
+}
+
+export function mergeRouterConfig(base: RouterConfig, override: Partial<RouterConfig> | undefined): RouterConfig {
+  if (!override || typeof override !== "object") return cloneConfig(base);
+
+  const merged = cloneConfig(base);
+
+  if (typeof override.enabled === "boolean") merged.enabled = override.enabled;
+  if (typeof override.defaultProfile === "string" && override.defaultProfile.trim()) {
+    merged.defaultProfile = override.defaultProfile.trim();
+  }
+  if (typeof override.lockOnManualModelChange === "boolean") {
+    merged.lockOnManualModelChange = override.lockOnManualModelChange;
+  }
+  if (typeof override.notifyOnRoute === "boolean") merged.notifyOnRoute = override.notifyOnRoute;
+
+  if (override.profiles && typeof override.profiles === "object" && !Array.isArray(override.profiles)) {
+    for (const [name, rawProfile] of Object.entries(override.profiles)) {
+      if (!name.trim() || !isObject(rawProfile)) continue;
+      merged.profiles[name] = {
+        ...(merged.profiles[name] ?? {}),
+        ...normalizeProfile(rawProfile),
+      };
+    }
+  }
+
+  if (Array.isArray(override.rules)) {
+    const rules = override.rules.map(normalizeRule).filter((rule): rule is RouterRule => rule !== undefined);
+    merged.rules = rules;
+  }
+
+  return merged;
+}
+
+export function resolveEffectiveConfig(config: RouterConfig, state: RouterState): RouterConfig {
+  const effective = cloneConfig(config);
+
+  if (state.profileOverrides) {
+    for (const [name, profile] of Object.entries(state.profileOverrides)) {
+      effective.profiles[name] = {
+        ...(effective.profiles[name] ?? {}),
+        ...normalizeProfile(profile),
+      };
+    }
+  }
+
+  return effective;
+}
+
+export function reconstructRouterState(entries: Array<Record<string, any>>, config: RouterConfig): RouterState {
+  let state = createDefaultRouterState(config);
+
+  for (const entry of entries) {
+    if (entry?.type !== "custom" || entry.customType !== AUTO_MODEL_ROUTER_ENTRY_TYPE) continue;
+    const data = entry.data;
+    if (!isObject(data)) continue;
+
+    const nextMode = normalizeMode(data.mode);
+    if (!nextMode) continue;
+
+    state = { mode: nextMode };
+
+    if (nextMode === "force" && typeof data.forcedProfile === "string" && data.forcedProfile.trim()) {
+      state.forcedProfile = data.forcedProfile.trim();
+    }
+
+    if (isObject(data.profileOverrides)) {
+      state.profileOverrides = normalizeProfileOverrides(data.profileOverrides);
+    }
+  }
+
+  return state;
+}
+
+export function serializeRouterState(state: RouterState): Record<string, any> {
+  return {
+    mode: state.mode,
+    forcedProfile: state.forcedProfile,
+    profileOverrides: state.profileOverrides,
+  };
+}
+
+export function buildRouterStatus(state: RouterState, config: RouterConfig, maxLength = 120): string {
+  let text: string;
+
+  if (state.mode === "off") {
+    text = "router: off";
+  } else if (state.mode === "locked") {
+    text = "router: locked";
+  } else if (state.mode === "force") {
+    text = `router: force→${state.forcedProfile ?? config.defaultProfile}`;
+  } else {
+    const profile = state.lastDecision?.profile ?? config.defaultProfile;
+    const reason = state.lastDecision?.reason;
+    text = `router: auto→${profile}${reason ? ` — ${reason}` : ""}`;
+  }
+
+  return truncateSingleLine(text, maxLength);
+}
+
+export function buildRouterDetails(
+  state: RouterState,
+  config: RouterConfig,
+  configPaths: string[] = [],
+): string {
+  const lines = [buildRouterStatus(state, config, 200), "", "Profiles:"];
+
+  for (const [name, profile] of Object.entries(config.profiles)) {
+    const model = profile.provider && profile.model ? `${profile.provider}/${profile.model}` : "(current model)";
+    const thinking = profile.thinkingLevel ? ` thinking:${profile.thinkingLevel}` : "";
+    const marker = name === config.defaultProfile ? " default" : "";
+    lines.push(`- ${name}:${marker} ${model}${thinking}`.replace(/:\s+default/, ": default"));
+  }
+
+  if (state.profileOverrides && Object.keys(state.profileOverrides).length > 0) {
+    lines.push("", "Session profile overrides:");
+    for (const [name, profile] of Object.entries(state.profileOverrides)) {
+      const model = profile.provider && profile.model ? `${profile.provider}/${profile.model}` : "(current model)";
+      const thinking = profile.thinkingLevel ? ` thinking:${profile.thinkingLevel}` : "";
+      lines.push(`- ${name}: ${model}${thinking}`);
+    }
+  }
+
+  if (state.lastDecision) {
+    lines.push("", `Last route: ${state.lastDecision.profile} (${state.lastDecision.reason})`);
+  }
+
+  if (configPaths.length > 0) {
+    lines.push("", "Config files:", ...configPaths.map((path) => `- ${path}`));
+  }
+
+  return lines.join("\n");
+}
+
+export function buildRouterConfigHelp(configPaths: string[]): string {
+  return [
+    "Auto model router config files, loaded in order:",
+    ...configPaths.map((path) => `- ${path}`),
+    "",
+    "Example auto-model-router.json:",
+    JSON.stringify(
+      {
+        enabled: true,
+        defaultProfile: "fast",
+        lockOnManualModelChange: true,
+        notifyOnRoute: true,
+        profiles: {
+          fast: { provider: "openai-codex", model: "gpt-5.3-codex-spark", thinkingLevel: "minimal" },
+          strong: { provider: "openai-codex", model: "gpt-5.5", thinkingLevel: "high" },
+        },
+        rules: [
+          { profile: "strong", patterns: ["\\b(plan|architecture|debug|refactor|complex)\\b"], reason: "hard task" },
+        ],
+      },
+      null,
+      2,
+    ),
+  ].join("\n");
+}
+
+export function truncateSingleLine(text: string, maxLength: number): string {
+  const compact = text.replace(/\s+/g, " ").trim();
+  if (compact.length <= maxLength) return compact;
+  if (maxLength <= 1) return compact.slice(0, Math.max(0, maxLength));
+  return `${compact.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+function matchesPattern(prompt: string, pattern: string): boolean {
+  try {
+    return new RegExp(pattern, "i").test(prompt);
+  } catch {
+    return false;
+  }
+}
+
+function cloneConfig(config: RouterConfig): RouterConfig {
+  return {
+    ...config,
+    profiles: Object.fromEntries(Object.entries(config.profiles).map(([name, profile]) => [name, { ...profile }])),
+    rules: config.rules.map((rule) => ({ ...rule, patterns: [...rule.patterns] })),
+  };
+}
+
+function normalizeProfile(raw: Record<string, any>): RouterProfile {
+  const profile: RouterProfile = {};
+
+  if (typeof raw.provider === "string" && raw.provider.trim()) profile.provider = raw.provider.trim();
+  if (typeof raw.model === "string" && raw.model.trim()) profile.model = raw.model.trim();
+  if (isThinkingLevel(raw.thinkingLevel)) profile.thinkingLevel = raw.thinkingLevel;
+  if (typeof raw.description === "string" && raw.description.trim()) profile.description = raw.description.trim();
+
+  return profile;
+}
+
+function normalizeRule(raw: any): RouterRule | undefined {
+  if (!isObject(raw)) return undefined;
+  if (typeof raw.profile !== "string" || !raw.profile.trim()) return undefined;
+  if (!Array.isArray(raw.patterns)) return undefined;
+
+  const patterns = raw.patterns.filter((pattern): pattern is string => typeof pattern === "string" && pattern.trim());
+  if (patterns.length === 0) return undefined;
+
+  return {
+    profile: raw.profile.trim(),
+    patterns,
+    reason: typeof raw.reason === "string" && raw.reason.trim() ? raw.reason.trim() : undefined,
+  };
+}
+
+function normalizeProfileOverrides(raw: Record<string, any>): Record<string, RouterProfile> | undefined {
+  const overrides: Record<string, RouterProfile> = {};
+
+  for (const [name, profile] of Object.entries(raw)) {
+    if (!name.trim() || !isObject(profile)) continue;
+    const normalized = normalizeProfile(profile);
+    if (Object.keys(normalized).length > 0) overrides[name] = normalized;
+  }
+
+  return Object.keys(overrides).length > 0 ? overrides : undefined;
+}
+
+function normalizeMode(value: unknown): RouterMode | undefined {
+  if (value === "auto" || value === "off" || value === "locked" || value === "force") return value;
+  return undefined;
+}
+
+function isThinkingLevel(value: unknown): value is ThinkingLevel {
+  return value === "off" || value === "minimal" || value === "low" || value === "medium" || value === "high" || value === "xhigh";
+}
+
+function isObject(value: unknown): value is Record<string, any> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/pi/auto-model-router/index.test.ts
+++ b/pi/auto-model-router/index.test.ts
@@ -1,0 +1,205 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import routerExtension from "./index.ts";
+import { AUTO_MODEL_ROUTER_ENTRY_TYPE } from "./core.ts";
+
+function createHarness(branch: Array<Record<string, any>> = []) {
+  const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const tempRoot = mkdtempSync(join(tmpdir(), "pi-router-test-"));
+  process.env.PI_CODING_AGENT_DIR = join(tempRoot, "agent");
+
+  const handlers = new Map<string, Array<Function>>();
+  const commands = new Map<string, any>();
+  const appended: Array<{ customType: string; data: Record<string, any> }> = [];
+  const notifications: Array<{ message: string; level: string }> = [];
+  const statuses = new Map<string, string | undefined>();
+  const flags = new Map<string, any>();
+
+  const models = {
+    "openai-codex/gpt-5.3-codex-spark": { provider: "openai-codex", id: "gpt-5.3-codex-spark", input: ["text"] },
+    "openai-codex/gpt-5.5": { provider: "openai-codex", id: "gpt-5.5", input: ["text", "image"] },
+    "anthropic/claude-sonnet": { provider: "anthropic", id: "claude-sonnet", input: ["text", "image"] },
+  } as Record<string, any>;
+
+  let currentModel = models["anthropic/claude-sonnet"];
+  let thinkingLevel = "medium";
+  let ctx: any;
+
+  const pi = {
+    on(name: string, handler: Function) {
+      handlers.set(name, [...(handlers.get(name) ?? []), handler]);
+    },
+    registerCommand(name: string, definition: any) {
+      commands.set(name, definition);
+    },
+    registerFlag(name: string, definition: any) {
+      flags.set(name, definition);
+    },
+    getFlag() {
+      return undefined;
+    },
+    appendEntry(customType: string, data: Record<string, any>) {
+      appended.push({ customType, data });
+    },
+    async setModel(model: any) {
+      const previousModel = currentModel;
+      currentModel = model;
+      for (const handler of handlers.get("model_select") ?? []) {
+        await handler({ source: "set", model, previousModel }, ctx);
+      }
+      return true;
+    },
+    getThinkingLevel() {
+      return thinkingLevel;
+    },
+    setThinkingLevel(level: string) {
+      thinkingLevel = level;
+    },
+  };
+
+  ctx = {
+    hasUI: true,
+    cwd: join(tempRoot, "project"),
+    sessionManager: {
+      getBranch: () => branch,
+    },
+    modelRegistry: {
+      find(provider: string, modelId: string) {
+        return models[`${provider}/${modelId}`];
+      },
+    },
+    ui: {
+      setStatus(key: string, value: string | undefined) {
+        statuses.set(key, value);
+      },
+      notify(message: string, level: string) {
+        notifications.push({ message, level });
+      },
+      async select(_title: string, choices: string[]) {
+        return choices[0];
+      },
+    },
+  };
+
+  Object.defineProperty(ctx, "model", { get: () => currentModel });
+
+  routerExtension(pi as any);
+
+  return {
+    appended,
+    cleanup() {
+      if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+      else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+    },
+    commands,
+    ctx,
+    flags,
+    get currentModel() {
+      return currentModel;
+    },
+    get thinkingLevel() {
+      return thinkingLevel;
+    },
+    handlers,
+    notifications,
+    statuses,
+  };
+}
+
+test("/router fast forces the fast profile and applies its model and thinking level", async () => {
+  const harness = createHarness();
+  try {
+    await harness.handlers.get("session_start")![0]!({}, harness.ctx);
+    await harness.commands.get("router").handler("fast", harness.ctx);
+
+    assert.equal(harness.currentModel.provider, "openai-codex");
+    assert.equal(harness.currentModel.id, "gpt-5.3-codex-spark");
+    assert.equal(harness.thinkingLevel, "minimal");
+    assert.deepEqual(
+      { customType: harness.appended.at(-1)?.customType, mode: harness.appended.at(-1)?.data.mode, forcedProfile: harness.appended.at(-1)?.data.forcedProfile },
+      { customType: AUTO_MODEL_ROUTER_ENTRY_TYPE, mode: "force", forcedProfile: "fast" },
+    );
+    assert.equal(harness.statuses.get("auto-model-router"), "router: force→fast");
+  } finally {
+    harness.cleanup();
+  }
+});
+
+test("automatic routing applies the strong profile before complex planning prompts", async () => {
+  const harness = createHarness();
+  try {
+    await harness.handlers.get("session_start")![0]!({}, harness.ctx);
+    const result = await harness.handlers.get("before_agent_start")![0]!({ prompt: "Plan a complex refactor", systemPrompt: "base" }, harness.ctx);
+
+    assert.equal(result, undefined);
+    assert.equal(harness.currentModel.provider, "openai-codex");
+    assert.equal(harness.currentModel.id, "gpt-5.5");
+    assert.equal(harness.thinkingLevel, "high");
+    assert.match(harness.statuses.get("auto-model-router") ?? "", /router: auto→strong/);
+    assert.match(harness.statuses.get("auto-model-router") ?? "", /matched/);
+  } finally {
+    harness.cleanup();
+  }
+});
+
+test("image prompts use an image-capable strong profile instead of the text-only fast default", async () => {
+  const harness = createHarness();
+  try {
+    await harness.handlers.get("session_start")![0]!({}, harness.ctx);
+    await harness.handlers.get("before_agent_start")![0]!({
+      prompt: "Describe this screenshot",
+      images: [{ type: "image" }],
+      systemPrompt: "base",
+    }, harness.ctx);
+
+    assert.equal(harness.currentModel.provider, "openai-codex");
+    assert.equal(harness.currentModel.id, "gpt-5.5");
+    assert.equal(harness.thinkingLevel, "high");
+    assert.match(harness.statuses.get("auto-model-router") ?? "", /image-capable model/);
+  } finally {
+    harness.cleanup();
+  }
+});
+
+test("/router set <profile> current stores a session profile override", async () => {
+  const harness = createHarness();
+  try {
+    await harness.handlers.get("session_start")![0]!({}, harness.ctx);
+    await harness.commands.get("router").handler("set fast current", harness.ctx);
+    await harness.commands.get("router").handler("fast", harness.ctx);
+
+    assert.equal(harness.currentModel.provider, "anthropic");
+    assert.equal(harness.currentModel.id, "claude-sonnet");
+    assert.equal(harness.thinkingLevel, "medium");
+    assert.equal(harness.appended.at(-2)?.customType, AUTO_MODEL_ROUTER_ENTRY_TYPE);
+    assert.deepEqual(harness.appended.at(-2)?.data.profileOverrides.fast, {
+      provider: "anthropic",
+      model: "claude-sonnet",
+      thinkingLevel: "medium",
+    });
+  } finally {
+    harness.cleanup();
+  }
+});
+
+test("manual model selection locks automatic routing", async () => {
+  const harness = createHarness();
+  try {
+    await harness.handlers.get("session_start")![0]!({}, harness.ctx);
+    await harness.handlers.get("model_select")![0]!({ source: "cycle", model: { provider: "anthropic", id: "claude-sonnet" } }, harness.ctx);
+
+    assert.equal(harness.appended.at(-1)?.customType, AUTO_MODEL_ROUTER_ENTRY_TYPE);
+    assert.equal(harness.appended.at(-1)?.data.mode, "locked");
+    assert.equal(harness.statuses.get("auto-model-router"), "router: locked");
+    assert.deepEqual(harness.notifications.at(-1), {
+      message: "Auto model router locked after manual model change. Use /router auto to re-enable.",
+      level: "info",
+    });
+  } finally {
+    harness.cleanup();
+  }
+});

--- a/pi/auto-model-router/index.ts
+++ b/pi/auto-model-router/index.ts
@@ -1,0 +1,384 @@
+// @ts-nocheck
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import {
+  AUTO_MODEL_ROUTER_ENTRY_TYPE,
+  DEFAULT_ROUTER_CONFIG,
+  buildRouterConfigHelp,
+  buildRouterDetails,
+  buildRouterStatus,
+  createDefaultRouterState,
+  decideRoute,
+  mergeRouterConfig,
+  parseRouterCommand,
+  reconstructRouterState,
+  resolveEffectiveConfig,
+  serializeRouterState,
+} from "./core.ts";
+
+const STATUS_KEY = "auto-model-router";
+const CONFIG_FILE = "auto-model-router.json";
+
+export default function autoModelRouterExtension(pi) {
+  let config = DEFAULT_ROUTER_CONFIG;
+  let configPaths = [];
+  let state = createDefaultRouterState(config);
+  let routerModelChange;
+
+  function getEffectiveConfig() {
+    return resolveEffectiveConfig(config, state);
+  }
+
+  function persistState() {
+    pi.appendEntry(AUTO_MODEL_ROUTER_ENTRY_TYPE, serializeRouterState(state));
+  }
+
+  function updateStatus(ctx) {
+    if (!ctx.hasUI) return;
+    ctx.ui.setStatus(STATUS_KEY, buildRouterStatus(state, getEffectiveConfig()));
+  }
+
+  function notify(ctx, message, level = "info") {
+    if (ctx.hasUI) ctx.ui.notify(message, level);
+  }
+
+  function reloadConfig(ctx) {
+    const loaded = loadRouterConfig(ctx.cwd, (message) => notify(ctx, message, "warning"));
+    config = loaded.config;
+    configPaths = loaded.paths;
+
+    if (state.mode === undefined) {
+      state = createDefaultRouterState(config);
+    }
+  }
+
+  async function applyProfile(profileName, reason, ctx) {
+    const effective = getEffectiveConfig();
+    const profile = effective.profiles[profileName];
+
+    if (!profile) {
+      notify(ctx, `Auto model router profile not found: ${profileName}`, "warning");
+      updateStatus(ctx);
+      return false;
+    }
+
+    let changed = false;
+    let modelApplied = false;
+    const hasConfiguredModel = Boolean(profile.provider && profile.model);
+
+    if (hasConfiguredModel) {
+      const model = ctx.modelRegistry.find(profile.provider, profile.model);
+      if (!model) {
+        notify(ctx, `Auto model router model not found: ${profile.provider}/${profile.model}`, "warning");
+        updateStatus(ctx);
+        return false;
+      }
+
+      if (modelKey(ctx.model) !== modelKey(model)) {
+        routerModelChange = { key: modelKey(model), timestamp: Date.now() };
+        const success = await pi.setModel(model);
+        if (!success) {
+          notify(ctx, `Auto model router cannot use ${profile.provider}/${profile.model}: no configured auth`, "warning");
+          updateStatus(ctx);
+          return false;
+        }
+        changed = true;
+      }
+      modelApplied = true;
+    }
+
+    if ((!hasConfiguredModel || modelApplied) && profile.thinkingLevel && pi.getThinkingLevel() !== profile.thinkingLevel) {
+      pi.setThinkingLevel(profile.thinkingLevel);
+      changed = true;
+    }
+
+    if (changed && config.notifyOnRoute) {
+      notify(ctx, `Auto model router: ${profileName} (${reason})`, "info");
+    }
+
+    updateStatus(ctx);
+    return true;
+  }
+
+  async function applyDecision(decision, ctx) {
+    state = { ...state, lastDecision: decision };
+    updateStatus(ctx);
+    return applyProfile(decision.profile, decision.reason, ctx);
+  }
+
+  async function setMode(mode, ctx) {
+    state = {
+      ...state,
+      mode,
+      forcedProfile: undefined,
+      lastDecision: undefined,
+    };
+    persistState();
+    updateStatus(ctx);
+    notify(ctx, `Auto model router mode: ${mode}`, "info");
+  }
+
+  async function forceProfile(profileName, ctx) {
+    const effective = getEffectiveConfig();
+    if (!effective.profiles[profileName]) {
+      notify(ctx, `Unknown auto model router profile: ${profileName}`, "warning");
+      return;
+    }
+
+    state = {
+      ...state,
+      mode: "force",
+      forcedProfile: profileName,
+      lastDecision: { profile: profileName, reason: "forced profile", mode: "force" },
+    };
+    persistState();
+    await applyProfile(profileName, "forced profile", ctx);
+  }
+
+  function setProfileToCurrent(profileName, ctx) {
+    if (!ctx.model) {
+      notify(ctx, "Cannot set router profile: no current model selected", "warning");
+      return;
+    }
+
+    state = {
+      ...state,
+      profileOverrides: {
+        ...(state.profileOverrides ?? {}),
+        [profileName]: {
+          provider: ctx.model.provider,
+          model: ctx.model.id,
+          thinkingLevel: pi.getThinkingLevel(),
+        },
+      },
+    };
+
+    persistState();
+    updateStatus(ctx);
+    notify(ctx, `Auto model router profile "${profileName}" set to ${ctx.model.provider}/${ctx.model.id} with thinking:${pi.getThinkingLevel()} for this session`, "info");
+  }
+
+  async function showSelector(ctx) {
+    const effective = getEffectiveConfig();
+    const profileNames = Object.keys(effective.profiles).sort();
+    const choices = [
+      "status",
+      "auto",
+      "off",
+      "lock",
+      ...profileNames.map((profile) => `profile ${profile}`),
+      ...profileNames.map((profile) => `set ${profile} current`),
+      "reload",
+      "config",
+    ];
+
+    const selected = await ctx.ui.select("Auto model router", choices);
+    if (!selected) return;
+    await handleRouterCommand(selected, ctx);
+  }
+
+  async function handleRouterCommand(args, ctx) {
+    const command = parseRouterCommand(args);
+
+    if (command.action === "show") {
+      if (ctx.hasUI) await showSelector(ctx);
+      else notify(ctx, buildRouterDetails(state, getEffectiveConfig(), configPaths), "info");
+      return;
+    }
+
+    if (command.action === "status") {
+      notify(ctx, buildRouterDetails(state, getEffectiveConfig(), configPaths), "info");
+      return;
+    }
+
+    if (command.action === "mode") {
+      await setMode(command.mode, ctx);
+      return;
+    }
+
+    if (command.action === "force") {
+      await forceProfile(command.profile, ctx);
+      return;
+    }
+
+    if (command.action === "set-current") {
+      setProfileToCurrent(command.profile, ctx);
+      return;
+    }
+
+    if (command.action === "reload") {
+      reloadConfig(ctx);
+      updateStatus(ctx);
+      notify(ctx, "Auto model router config reloaded", "info");
+      return;
+    }
+
+    if (command.action === "config") {
+      notify(ctx, buildRouterConfigHelp(configPaths.length > 0 ? configPaths : getConfigPaths(ctx.cwd)), "info");
+      return;
+    }
+
+    notify(ctx, buildRouterHelp(), "info");
+  }
+
+  pi.registerFlag("router", {
+    description: "Auto model router mode/profile (auto, off, lock, fast, strong)",
+    type: "string",
+  });
+
+  pi.registerCommand("router", {
+    description: "Configure automatic task-scale model routing",
+    getArgumentCompletions: (prefix) => {
+      const effective = getEffectiveConfig();
+      const builtins = ["status", "auto", "off", "lock", "unlock", "reload", "config", "help"];
+      const profileCommands = Object.keys(effective.profiles).flatMap((profile) => [profile, `profile ${profile}`, `set ${profile} current`]);
+      const items = [...builtins, ...profileCommands]
+        .filter((value) => value.startsWith(prefix))
+        .map((value) => ({ value, label: value }));
+      return items.length > 0 ? items : null;
+    },
+    handler: async (args, ctx) => {
+      await handleRouterCommand(args, ctx);
+    },
+  });
+
+  pi.on("session_start", async (_event, ctx) => {
+    reloadConfig(ctx);
+    state = reconstructRouterState(ctx.sessionManager.getBranch(), config);
+
+    const routerFlag = pi.getFlag("router");
+    if (typeof routerFlag === "string" && routerFlag.trim()) {
+      await handleRouterCommand(routerFlag, ctx);
+    }
+
+    updateStatus(ctx);
+  });
+
+  pi.on("session_tree", async (_event, ctx) => {
+    state = reconstructRouterState(ctx.sessionManager.getBranch(), config);
+    updateStatus(ctx);
+  });
+
+  pi.on("before_agent_start", async (event, ctx) => {
+    const effective = getEffectiveConfig();
+    let decision = decideRoute(event.prompt ?? "", effective, state);
+    if (!decision) {
+      updateStatus(ctx);
+      return;
+    }
+
+    if (hasImages(event) && !isProfileImageCapable(decision.profile, effective, ctx)) {
+      const imageProfile = findImageCapableProfile(effective, ctx);
+      if (!imageProfile) {
+        notify(ctx, "Auto model router skipped image prompt: no configured image-capable profile found", "warning");
+        updateStatus(ctx);
+        return;
+      }
+
+      decision = {
+        ...decision,
+        profile: imageProfile,
+        reason: "image input requires image-capable model",
+        matchedPattern: undefined,
+      };
+    }
+
+    await applyDecision(decision, ctx);
+  });
+
+  pi.on("model_select", async (event, ctx) => {
+    if (!config.lockOnManualModelChange) return;
+    if (event.source === "restore") return;
+    if (state.mode === "off" || state.mode === "locked") return;
+
+    const selectedKey = modelKey(event.model);
+    if (routerModelChange && routerModelChange.key === selectedKey && Date.now() - routerModelChange.timestamp < 2000) {
+      return;
+    }
+
+    state = {
+      ...state,
+      mode: "locked",
+      forcedProfile: undefined,
+      lastDecision: undefined,
+    };
+    persistState();
+    updateStatus(ctx);
+    notify(ctx, "Auto model router locked after manual model change. Use /router auto to re-enable.", "info");
+  });
+}
+
+function hasImages(event) {
+  return Array.isArray(event.images) && event.images.length > 0;
+}
+
+function findImageCapableProfile(config, ctx) {
+  const orderedProfiles = unique(["strong", config.defaultProfile, ...Object.keys(config.profiles)]);
+  return orderedProfiles.find((profileName) => isProfileImageCapable(profileName, config, ctx));
+}
+
+function isProfileImageCapable(profileName, config, ctx) {
+  const profile = config.profiles[profileName];
+  if (!profile) return false;
+
+  if (!profile.provider || !profile.model) {
+    return modelSupportsImage(ctx.model);
+  }
+
+  const model = ctx.modelRegistry.find(profile.provider, profile.model);
+  return modelSupportsImage(model);
+}
+
+function modelSupportsImage(model) {
+  return Array.isArray(model?.input) && model.input.includes("image");
+}
+
+function unique(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function loadRouterConfig(cwd, onWarning) {
+  const paths = getConfigPaths(cwd);
+  let config = DEFAULT_ROUTER_CONFIG;
+
+  for (const path of paths) {
+    if (!existsSync(path)) continue;
+
+    try {
+      const parsed = JSON.parse(readFileSync(path, "utf8"));
+      config = mergeRouterConfig(config, parsed);
+    } catch (error) {
+      onWarning?.(`Failed to load auto model router config ${path}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  return { config, paths };
+}
+
+function getConfigPaths(cwd) {
+  return [join(getAgentDir(), CONFIG_FILE), join(cwd, ".pi", CONFIG_FILE)];
+}
+
+function getAgentDir() {
+  return process.env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent");
+}
+
+function modelKey(model) {
+  if (!model) return undefined;
+  return `${model.provider}/${model.id}`;
+}
+
+function buildRouterHelp() {
+  return [
+    "Auto model router commands:",
+    "- /router: interactive selector",
+    "- /router status: show current mode and profiles",
+    "- /router auto|off|lock|unlock: change mode",
+    "- /router fast or /router strong: force a profile",
+    "- /router set <profile> current: set a profile to the current model/thinking for this session",
+    "- /router reload: reload config files",
+    "- /router config: show config paths and example",
+  ].join("\n");
+}


### PR DESCRIPTION
## Summary
- Add a Pi auto-model-router extension with fast/strong rule-based profiles and `/router` controls
- Support JSON config, session profile overrides, manual model-change locking, and image-aware routing
- Install the extension via Home Manager and add flake checks for router tests

## Test Plan
- [x] node --test pi/assistant-insight/core.test.ts pi/goal/core.test.ts pi/goal/index.test.ts pi/subagents/core.test.ts pi/auto-model-router/core.test.ts pi/auto-model-router/index.test.ts
- [x] nix flake check
- [x] home-manager switch --flake .#nixos@wsl