### PR TITLE
:fire: chore(headroom): remove headroom-ai MCP server integration

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -50,27 +50,6 @@
         "type": "github"
       }
     },
-    "headroom": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_2",
-        "pyproject-build-systems": "pyproject-build-systems",
-        "pyproject-nix": "pyproject-nix",
-        "uv2nix": "uv2nix"
-      },
-      "locked": {
-        "lastModified": 1780396287,
-        "narHash": "sha256-w4U1jzrklqzvzYyLxnCypxbxJivbDJrWv6+zqNTKgPU=",
-        "owner": "LITl-l",
-        "repo": "headroom-overlay",
-        "rev": "7676f3ef19d1b4c4a4fef8e2048dcfd99b50f099",
-        "type": "github"
-      },
-      "original": {
-        "owner": "LITl-l",
-        "repo": "headroom-overlay",
-        "type": "github"
-      }
-    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -125,22 +104,6 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1780336545,
-        "narHash": "sha256-vhVhuXzFrIOfcssC/9hDHx7MHzDKjF3keHuREOQqQiQ=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "4df1b885d76a54e1aa1a318f8d16fd6005b6401f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
         "lastModified": 1773646010,
         "narHash": "sha256-iYrs97hS7p5u4lQzuNWzuALGIOdkPXvjz7bviiBjUu8=",
         "owner": "nixos",
@@ -157,7 +120,7 @@
     },
     "pi": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_3",
         "systems": "systems"
       },
       "locked": {
@@ -174,64 +137,13 @@
         "type": "github"
       }
     },
-    "pyproject-build-systems": {
-      "inputs": {
-        "nixpkgs": [
-          "headroom",
-          "nixpkgs"
-        ],
-        "pyproject-nix": [
-          "headroom",
-          "pyproject-nix"
-        ],
-        "uv2nix": [
-          "headroom",
-          "uv2nix"
-        ]
-      },
-      "locked": {
-        "lastModified": 1779676664,
-        "narHash": "sha256-MbXylBTkWqVm8/VYjoULtMoVRgWBN1gSHbeRKsOsPlU=",
-        "owner": "pyproject-nix",
-        "repo": "build-system-pkgs",
-        "rev": "7bff980f37fc24e09dbc986643719900c139bf12",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "build-system-pkgs",
-        "type": "github"
-      }
-    },
-    "pyproject-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "headroom",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778901413,
-        "narHash": "sha256-GSKXTAnFqRAMlZkJrIPcQMYf+lpMr66K3i60mB9STvc=",
-        "owner": "pyproject-nix",
-        "repo": "pyproject.nix",
-        "rev": "a228447c3e179d477c1b6246ef3efa8cfe3c469a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "pyproject.nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "claude-code": "claude-code",
         "fish-plugin-fzf": "fish-plugin-fzf",
         "fish-plugin-z": "fish-plugin-z",
-        "headroom": "headroom",
         "home-manager": "home-manager",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_2",
         "pi": "pi"
       }
     },
@@ -247,31 +159,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "uv2nix": {
-      "inputs": {
-        "nixpkgs": [
-          "headroom",
-          "nixpkgs"
-        ],
-        "pyproject-nix": [
-          "headroom",
-          "pyproject-nix"
-        ]
-      },
-      "locked": {
-        "lastModified": 1780358675,
-        "narHash": "sha256-n4jX4svZwmoWpzhz3If9wkvEYKv3WuDvprE8vi57MRY=",
-        "owner": "pyproject-nix",
-        "repo": "uv2nix",
-        "rev": "3a557a9e78cc5b11bc9a610f27da4bdd5599edfe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "uv2nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -32,11 +32,6 @@
     pi = {
       url = "github:lukasl-dev/pi.nix";
     };
-
-    # headroom context-compression MCP server (native binary via Cachix)
-    headroom = {
-      url = "github:LITl-l/headroom-overlay";
-    };
   };
 
   outputs = { self, nixpkgs, home-manager, ... }@inputs:
@@ -54,10 +49,6 @@
         overlays = [
           inputs.claude-code.overlays.default
           inputs.pi.overlays.default
-        ] ++ nixpkgs.lib.optionals (system == "x86_64-linux") [
-          # headroom-overlay only publishes x86_64-linux; gate it so the
-          # darwin/aarch64 configs (and `nix flake check`) still evaluate.
-          inputs.headroom.overlays.default
         ];
       });
     in

--- a/home.nix
+++ b/home.nix
@@ -68,11 +68,6 @@ in
     nixpkgs-fmt # Nix formatter
     nil # Nix LSP
     nix-manager # Custom nix-manager command
-  ] ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
-    # headroom-ai context-compression CLI + MCP server (via LITl-l/headroom-overlay).
-    # Linux-guarded: the overlay only publishes x86_64-linux. pkgs.headroom is
-    # fully qualified because this append is outside the `with pkgs;` scope above.
-    pkgs.headroom
   ];
 
   # Environment variables
@@ -82,16 +77,6 @@ in
     PAGER = "less";
     LESS = "-R";
     BROWSER = "xdg-open";
-
-    # Opt out of headroom-ai's on-by-default telemetry. Its TelemetryBeacon
-    # (site-packages/headroom/telemetry/beacon.py) otherwise POSTs anonymous
-    # aggregate stats — plus a SHA256(hostname) machine fingerprint — to a
-    # hardcoded Supabase endpoint every 5 minutes. This is headroom's documented
-    # kill-switch; collector.py honours it too (gates the /v1/telemetry report).
-    # Set at session scope so the `headroom` CLI *and* the MCP servers (which
-    # inherit this env) are covered; also baked into each MCP registration as
-    # defense-in-depth (see modules/claude-code.nix and modules/pi.nix).
-    HEADROOM_TELEMETRY = "off";
 
     # XDG directories
     XDG_CONFIG_HOME = "${config.home.homeDirectory}/.config";
@@ -115,9 +100,6 @@ in
       accept-flake-config = true
       extra-substituters = https://ryoppippi.cachix.org https://pi.cachix.org
       extra-trusted-public-keys = ryoppippi.cachix.org-1:b2LbtWNvJeL/qb1B6TYOMK+apaCps4SCbzlPRfSQIms= pi.cachix.org-1:lGeoGJaZ5ZDabuRzkcD5EBTNnDM4HJ1vqeOxlWk1Flk=
-      # headroom-overlay cachix cache (deferred): once the cache + public key exist,
-      # append " https://headroom-overlay.cachix.org" to extra-substituters above and
-      # " headroom-overlay.cachix.org-1:<KEY>" to extra-trusted-public-keys above.
       !include ${config.home.homeDirectory}/.config/nix/nix.local.conf
     '';
   };

--- a/modules/claude-code.nix
+++ b/modules/claude-code.nix
@@ -19,26 +19,4 @@ in
       "${dotfilesClaudePath}/setup-marketplace.sh" --update 2>/dev/null || true
     fi
   '';
-
-  # Register headroom-ai's stdio MCP server with Claude Code at user scope. MCP
-  # servers live in the stateful ~/.claude.json, so we delegate the file
-  # location/format to the `claude` CLI rather than managing it declaratively.
-  #
-  # `claude` is invoked by absolute store path because the new generation's bin/
-  # is not on PATH during activation; `headroom` is registered as a *bare*
-  # command (resolved from PATH when Claude launches it), which keeps the entry
-  # stable across headroom updates.
-  #
-  # HEADROOM_TELEMETRY=off is baked into the registration to disable headroom's
-  # on-by-default Supabase telemetry beacon for this MCP server (it also inherits
-  # the session var from home.nix; this is belt-and-suspenders). The guard greps
-  # the entry's Environment for HEADROOM_TELEMETRY so an existing env-less
-  # registration (added before this change) is reconciled exactly once: when the
-  # var is absent we remove + re-add with it; when already present we no-op.
-  home.activation.registerHeadroomMcp = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    if ! ${pkgs.claude-code}/bin/claude mcp get headroom 2>/dev/null | grep -q HEADROOM_TELEMETRY; then
-      ${pkgs.claude-code}/bin/claude mcp remove headroom -s user >/dev/null 2>&1 || true
-      ${pkgs.claude-code}/bin/claude mcp add headroom -s user -e HEADROOM_TELEMETRY=off -- headroom mcp serve >/dev/null 2>&1 || true
-    fi
-  '';
 }

--- a/modules/pi.nix
+++ b/modules/pi.nix
@@ -30,27 +30,6 @@
 
   home.file.".pi/agent/themes/claude-code.json".source = ../pi/claude-code-theme.json;
 
-  # Register headroom-ai's context-compression MCP server (stdio transport). Pi
-  # reads ~/.pi/agent/mcp.json. lifecycle "lazy" means Pi only spawns the server
-  # when a headroom_* tool is actually invoked. headroom is on PATH on Linux via
-  # home.packages (LITl-l/headroom-overlay).
-  #
-  # env HEADROOM_TELEMETRY=off disables headroom's on-by-default Supabase
-  # telemetry beacon for this server regardless of the inherited environment
-  # (mirrors the session var in home.nix and the Claude registration).
-  home.file.".pi/agent/mcp.json".text = ''
-    {
-      "mcpServers": {
-        "headroom": {
-          "command": "headroom",
-          "args": ["mcp", "serve"],
-          "env": { "HEADROOM_TELEMETRY": "off" },
-          "lifecycle": "lazy"
-        }
-      }
-    }
-  '';
-
   # Keep existing pi settings/auth intact, but select the Claude Code-like theme.
   home.activation.setPiClaudeCodeTheme = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     settings="$HOME/.pi/agent/settings.json"


### PR DESCRIPTION
## Summary

Reverts the headroom-ai integration added in #171 and hardened in #173. Removes all four layers wired across those PRs:

- **flake.nix** — drop the `headroom` input and its `x86_64-linux`-guarded overlay
- **flake.lock** — re-locked, dropping the `headroom` node plus its `uv2nix` / `pyproject-nix` / `pyproject-build-systems` transitive inputs
- **home.nix** — remove `pkgs.headroom` from `home.packages`, the `HEADROOM_TELEMETRY=off` session variable, and the deferred cachix note
- **modules/pi.nix** — drop the declarative `~/.pi/agent/mcp.json` registration
- **modules/claude-code.nix** — drop the `registerHeadroomMcp` activation script

## Verification

- `nix flake check` — passes (all 5 checks)
- `home-manager switch --flake .#nixos@wsl` — passes
- Post-switch: `headroom` no longer on PATH, no `HEADROOM_TELEMETRY` in generated env, Pi `mcp.json` absent, Claude Code has no headroom MCP registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)