### PR TITLE
:sparkles: feat(crumb): add zero-dependency context store-and-stub MCP server + CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 result
 result-*
 
+# Go build artifacts (crumb: `go build ./...` drops a binary beside the source)
+/pkgs/crumb/crumb
+
 # Nix temporary files
 .direnv/
 

--- a/docs/superpowers/plans/2026-06-03-crumb.md
+++ b/docs/superpowers/plans/2026-06-03-crumb.md
@@ -1,0 +1,2028 @@
+# crumb Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the headroom-ai MCP integration with `crumb`, a zero-dependency pure-Go static binary that does reversible context store-and-stub (compress/retrieve/stats) as both an MCP stdio server and a CLI, then purge every headroom reference from the dotfiles.
+
+**Architecture:** A single Go module (`pkgs/crumb`, standard library only) compiled with `buildGoModule` (`vendorHash = null`). `compress` stores content content-addressed under `~/.local/state/crumb/blobs/<hash>` and returns a heuristic stub; `retrieve` reads it back (optionally query-filtered); `stats` folds an append-only `events.jsonl`. The same core functions back both the MCP JSON-RPC stdio loop and the CLI. Nix wiring swaps `pkgs.headroom` for an in-repo `pkgs.crumb` overlay and re-registers the MCP server under the `crumb` name in Pi and Claude Code.
+
+**Tech Stack:** Go (stdlib: `encoding/json`, `crypto/sha256`, `os`, `bufio`, `bytes`, `time`); Nix flakes + Home Manager (`buildGoModule`); jujutsu (jj) for VCS.
+
+**VCS note:** This repo uses **jujutsu**, never git. Each "Commit" step uses `jj commit -m "…"` (always pass `-m`). All paths are inside the workspace `/home/nixos/wkspace/worktree/feat/crumb`. The design spec lives at `docs/superpowers/specs/2026-06-03-crumb-design.md` (already committed as the parent change).
+
+---
+
+## File Structure
+
+```
+pkgs/crumb/
+  default.nix      buildGoModule derivation (vendorHash = null, doCheck = true, static)
+  go.mod           module crumb; go 1.23; no require block
+  store.go         Store: content-addressed blobs, event log, stats, gc, env config
+  store_test.go
+  summary.go       token estimate, type detection, stub render, query filter
+  summary_test.go
+  ops.go           CompressContent / RetrieveContent / StatsText / dispatchTool (shared core)
+  ops_test.go
+  mcp.go           JSON-RPC 2.0 stdio server (initialize, tools/list, tools/call, ping)
+  mcp_test.go
+  main.go          CLI dispatch: mcp | compress | retrieve | stats | gc | version | help
+```
+
+Modified (Nix wiring, Phase 2):
+- `flake.nix` — drop headroom input + overlay gating; add crumb overlay + check
+- `home.nix` — `pkgs.headroom` → `crumb`; remove `HEADROOM_TELEMETRY` + cachix comments
+- `modules/pi.nix` — re-register MCP as `crumb`, drop telemetry env
+- `modules/claude-code.nix` — register `crumb`, remove headroom registration
+
+Package responsibilities (all `package main`, one binary):
+- `store` — durable state; knows nothing about MCP or stubs. Depends on `os`, `crypto/sha256`.
+- `summary` — pure functions over `[]byte`; no I/O. Depends on `encoding/json`.
+- `ops` — orchestrates store + summary into the three operations + tool dispatch.
+- `mcp` — JSON-RPC framing only; calls `ops`.
+- `main` — argv parsing only; calls `ops` / `mcp`.
+
+---
+
+## Phase 1 — Go implementation (TDD)
+
+### Task 1: Scaffold the Go module and make it build
+
+**Files:**
+- Create: `pkgs/crumb/go.mod`
+- Create: `pkgs/crumb/main.go`
+
+- [ ] **Step 1: Create `go.mod`**
+
+```
+module crumb
+
+go 1.23
+```
+
+- [ ] **Step 2: Create a minimal `main.go` that compiles**
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// version is overridden at build time via -ldflags "-X main.version=…".
+var version = "dev"
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+	switch os.Args[1] {
+	case "--version", "-v", "version":
+		fmt.Println("crumb", version)
+	case "--help", "-h", "help":
+		usage()
+	default:
+		fmt.Fprintln(os.Stderr, "unknown command:", os.Args[1])
+		usage()
+		os.Exit(2)
+	}
+}
+
+func usage() {
+	fmt.Fprint(os.Stderr, `crumb — context store-and-stub
+
+usage:
+  crumb mcp                          run the stdio MCP server
+  crumb compress [FILE|-]            store content, print the crumb stub
+  crumb retrieve <hash> [--query Q]  print stored content (optionally filtered)
+  crumb stats [--json]               print savings + recent events
+  crumb gc [--days N] [--max-mb M] [--all]   prune old/oversized blobs
+  crumb --version | --help
+`)
+}
+```
+
+- [ ] **Step 3: Verify it builds and runs**
+
+Run: `cd /home/nixos/wkspace/worktree/feat/crumb/pkgs/crumb && go build ./... && go run . --version`
+Expected: prints `crumb dev`, exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/nixos/wkspace/worktree/feat/crumb
+jj commit -m ":construction: feat(crumb): scaffold Go module + CLI entrypoint"
+```
+
+---
+
+### Task 2: Content-addressed store — Hash / Put / Get / dedup
+
+**Files:**
+- Create: `pkgs/crumb/store.go`
+- Test: `pkgs/crumb/store_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("CRUMB_HASH_LEN", "12")
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	return s
+}
+
+func TestPutGetRoundtrip(t *testing.T) {
+	s := newTestStore(t)
+	content := []byte(`{"hello":"world","n":[1,2,3]}`)
+	h, err := s.Put(content)
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if len(h) != 12 {
+		t.Fatalf("hash len = %d, want 12", len(h))
+	}
+	got, err := s.Get(h)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("roundtrip mismatch: got %q want %q", got, content)
+	}
+}
+
+func TestPutDedup(t *testing.T) {
+	s := newTestStore(t)
+	c := []byte("the same content, twice")
+	h1, _ := s.Put(c)
+	h2, _ := s.Put(c)
+	if h1 != h2 {
+		t.Fatalf("dedup: hashes differ %q vs %q", h1, h2)
+	}
+	entries, _ := os.ReadDir(filepath.Join(s.dir, "blobs"))
+	n := 0
+	for _, e := range entries {
+		if e.Name()[0] != '.' {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("dedup: expected 1 blob, found %d", n)
+	}
+}
+
+func TestGetNotFound(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.Get("deadbeef0000"); err != ErrNotFound {
+		t.Fatalf("Get(missing) err = %v, want ErrNotFound", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd pkgs/crumb && go test ./...`
+Expected: compile error (`undefined: Store`, `NewStore`, `ErrNotFound`).
+
+- [ ] **Step 3: Write `store.go` (store core only)**
+
+```go
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+// ErrNotFound is returned when a hash has no stored blob (never stored, or gc'd).
+var ErrNotFound = errors.New("crumb: not found (may have been gc'd)")
+
+// Store is a content-addressed blob store with an append-only event log.
+type Store struct {
+	dir       string
+	blobsDir  string
+	eventsLog string
+	hashLen   int
+}
+
+// DefaultDir resolves the store root: $CRUMB_DIR, else $XDG_STATE_HOME/crumb,
+// else ~/.local/state/crumb.
+func DefaultDir() string {
+	if d := os.Getenv("CRUMB_DIR"); d != "" {
+		return d
+	}
+	if d := os.Getenv("XDG_STATE_HOME"); d != "" {
+		return filepath.Join(d, "crumb")
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".local", "state", "crumb")
+}
+
+func hashLenFromEnv() int {
+	if v := os.Getenv("CRUMB_HASH_LEN"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 6 && n <= 64 {
+			return n
+		}
+	}
+	return 12
+}
+
+// NewStore creates the store directories if needed.
+func NewStore(dir string) (*Store, error) {
+	s := &Store{
+		dir:       dir,
+		blobsDir:  filepath.Join(dir, "blobs"),
+		eventsLog: filepath.Join(dir, "events.jsonl"),
+		hashLen:   hashLenFromEnv(),
+	}
+	if err := os.MkdirAll(s.blobsDir, 0o755); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// Hash returns the canonical short id (truncated sha256 hex) for content.
+func (s *Store) Hash(content []byte) string {
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:])[:s.hashLen]
+}
+
+func (s *Store) blobPath(hash string) string {
+	return filepath.Join(s.blobsDir, hash)
+}
+
+// Put stores content (dedup by hash) using an atomic temp-write + rename, and
+// returns its hash.
+func (s *Store) Put(content []byte) (string, error) {
+	hash := s.Hash(content)
+	path := s.blobPath(hash)
+	if _, err := os.Stat(path); err == nil {
+		return hash, nil // already stored
+	}
+	tmp, err := os.CreateTemp(s.blobsDir, ".tmp-*")
+	if err != nil {
+		return "", err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(content); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return "", err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return "", err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName)
+		return "", err
+	}
+	return hash, nil
+}
+
+// Get returns stored content for hash, or ErrNotFound.
+func (s *Store) Get(hash string) ([]byte, error) {
+	data, err := os.ReadFile(s.blobPath(hash))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return data, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd pkgs/crumb && go test ./...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/nixos/wkspace/worktree/feat/crumb
+jj commit -m ":sparkles: feat(crumb): content-addressed blob store with dedup"
+```
+
+---
+
+### Task 3: Event log, stats, and garbage collection
+
+**Files:**
+- Modify: `pkgs/crumb/store.go` (append types + methods)
+- Modify: `pkgs/crumb/store_test.go`
+
+- [ ] **Step 1: Write the failing tests (append to `store_test.go`)**
+
+```go
+import "time" // add to the existing import block
+
+func TestEventsAndStats(t *testing.T) {
+	s := newTestStore(t)
+	s.Put([]byte("aaaa"))
+	if err := s.AppendEvent(Event{TS: 1, Op: "compress", Hash: "h1", OrigTok: 100, StubTok: 10}); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+	s.AppendEvent(Event{TS: 2, Op: "compress", Hash: "h2", OrigTok: 50, StubTok: 5})
+	st, err := s.ReadStats(10)
+	if err != nil {
+		t.Fatalf("ReadStats: %v", err)
+	}
+	if st.Compressions != 2 {
+		t.Fatalf("Compressions = %d, want 2", st.Compressions)
+	}
+	if st.SavedTokens != (100-10)+(50-5) {
+		t.Fatalf("SavedTokens = %d, want 135", st.SavedTokens)
+	}
+	if len(st.Recent) != 2 {
+		t.Fatalf("Recent = %d, want 2", len(st.Recent))
+	}
+}
+
+func TestGCByAge(t *testing.T) {
+	s := newTestStore(t)
+	h, _ := s.Put([]byte("old content here"))
+	// backdate the blob's mtime by 30 days
+	old := time.Now().Add(-30 * 24 * time.Hour)
+	os.Chtimes(s.blobPath(h), old, old)
+	res, err := s.GC(time.Now(), 14*24*time.Hour, 0)
+	if err != nil {
+		t.Fatalf("GC: %v", err)
+	}
+	if res.Removed != 1 {
+		t.Fatalf("GC removed %d, want 1", res.Removed)
+	}
+	if _, err := s.Get(h); err != ErrNotFound {
+		t.Fatalf("after GC Get err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestGCBySize(t *testing.T) {
+	s := newTestStore(t)
+	// three distinct blobs, ~1000 bytes each
+	for i := 0; i < 3; i++ {
+		buf := make([]byte, 1000)
+		for j := range buf {
+			buf[j] = byte('a' + i)
+		}
+		s.Put(buf)
+	}
+	// cap at 1500 bytes -> at least one blob must be evicted
+	res, err := s.GC(time.Now(), 0, 1500)
+	if err != nil {
+		t.Fatalf("GC: %v", err)
+	}
+	if res.Removed < 1 {
+		t.Fatalf("GC by size removed %d, want >=1", res.Removed)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd pkgs/crumb && go test ./...`
+Expected: compile error (`undefined: Event`, `AppendEvent`, `ReadStats`, `GC`).
+
+- [ ] **Step 3: Implement event log + stats + gc (append to `store.go`)**
+
+Add `"bufio"`, `"encoding/json"`, `"sort"`, and `"time"` to the `store.go` import block, then append:
+
+```go
+// Event is one row in events.jsonl.
+type Event struct {
+	TS      int64  `json:"ts"`
+	Op      string `json:"op"`
+	Hash    string `json:"hash"`
+	OrigTok int    `json:"orig_tok"`
+	StubTok int    `json:"stub_tok"`
+}
+
+// AppendEvent appends one event via O_APPEND (atomic for small writes on POSIX).
+func (s *Store) AppendEvent(e Event) error {
+	f, err := os.OpenFile(s.eventsLog, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	line, err := json.Marshal(e)
+	if err != nil {
+		return err
+	}
+	line = append(line, '\n')
+	_, err = f.Write(line)
+	return err
+}
+
+// Stats aggregates the event log plus on-disk usage.
+type Stats struct {
+	Compressions int
+	UniqueBlobs  int
+	OrigTokens   int
+	StubTokens   int
+	SavedTokens  int
+	StoreBytes   int64
+	Recent       []Event
+}
+
+// ReadStats folds events.jsonl into totals, keeping the last recentN events.
+func (s *Store) ReadStats(recentN int) (Stats, error) {
+	var st Stats
+	f, err := os.Open(s.eventsLog)
+	if err != nil {
+		if os.IsNotExist(err) {
+			st.StoreBytes, st.UniqueBlobs = s.diskUsage()
+			return st, nil
+		}
+		return st, err
+	}
+	defer f.Close()
+
+	var events []Event
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 1024*1024), 64*1024*1024)
+	for sc.Scan() {
+		var e Event
+		if json.Unmarshal(sc.Bytes(), &e) != nil {
+			continue // skip a corrupt line rather than fail
+		}
+		events = append(events, e)
+		if e.Op == "compress" {
+			st.Compressions++
+			st.OrigTokens += e.OrigTok
+			st.StubTokens += e.StubTok
+		}
+	}
+	st.SavedTokens = st.OrigTokens - st.StubTokens
+	st.StoreBytes, st.UniqueBlobs = s.diskUsage()
+	if recentN > 0 && len(events) > recentN {
+		st.Recent = events[len(events)-recentN:]
+	} else {
+		st.Recent = events
+	}
+	return st, nil
+}
+
+func (s *Store) diskUsage() (int64, int) {
+	entries, err := os.ReadDir(s.blobsDir)
+	if err != nil {
+		return 0, 0
+	}
+	var total int64
+	n := 0
+	for _, e := range entries {
+		if e.IsDir() || e.Name()[0] == '.' {
+			continue // skip leftover .tmp-* files
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		total += info.Size()
+		n++
+	}
+	return total, n
+}
+
+// GCResult reports what GC removed.
+type GCResult struct {
+	Removed    int
+	FreedBytes int64
+}
+
+// GC removes blobs older than maxAge (when >0), then removes the oldest
+// remaining blobs until total size is under maxBytes (when >0). now is injected
+// so tests are deterministic.
+func (s *Store) GC(now time.Time, maxAge time.Duration, maxBytes int64) (GCResult, error) {
+	var res GCResult
+	entries, err := os.ReadDir(s.blobsDir)
+	if err != nil {
+		return res, err
+	}
+	type blob struct {
+		path string
+		size int64
+		mod  time.Time
+	}
+	var blobs []blob
+	for _, e := range entries {
+		if e.IsDir() || e.Name()[0] == '.' {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		blobs = append(blobs, blob{s.blobPath(e.Name()), info.Size(), info.ModTime()})
+	}
+
+	var remaining []blob
+	for _, b := range blobs {
+		if maxAge > 0 && now.Sub(b.mod) > maxAge {
+			if os.Remove(b.path) == nil {
+				res.Removed++
+				res.FreedBytes += b.size
+			}
+			continue
+		}
+		remaining = append(remaining, b)
+	}
+
+	if maxBytes > 0 {
+		var total int64
+		for _, b := range remaining {
+			total += b.size
+		}
+		if total > maxBytes {
+			sort.Slice(remaining, func(i, j int) bool { return remaining[i].mod.Before(remaining[j].mod) })
+			for _, b := range remaining {
+				if total <= maxBytes {
+					break
+				}
+				if os.Remove(b.path) == nil {
+					res.Removed++
+					res.FreedBytes += b.size
+					total -= b.size
+				}
+			}
+		}
+	}
+	return res, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd pkgs/crumb && go test ./...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/nixos/wkspace/worktree/feat/crumb
+jj commit -m ":sparkles: feat(crumb): event log, stats aggregation, and gc"
+```
+
+---
+
+### Task 4: Summary — token estimate, type detection, stub render, query filter
+
+**Files:**
+- Create: `pkgs/crumb/summary.go`
+- Test: `pkgs/crumb/summary_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEstimateTokens(t *testing.T) {
+	if got := EstimateTokens([]byte("abcdefgh")); got != 2 {
+		t.Fatalf("EstimateTokens(8 chars) = %d, want 2", got)
+	}
+}
+
+func TestDetectJSONObject(t *testing.T) {
+	sum := detectSummary([]byte(`{"results":[1,2,3],"meta":{},"page":1}`))
+	if sum.Type != "json" {
+		t.Fatalf("type = %q, want json", sum.Type)
+	}
+	if !strings.Contains(sum.Detail, "results(3)") {
+		t.Fatalf("detail %q missing results(3)", sum.Detail)
+	}
+}
+
+func TestDetectJSONArray(t *testing.T) {
+	sum := detectSummary([]byte(`[{"id":1},{"id":2}]`))
+	if sum.Type != "json" || !strings.Contains(sum.Detail, "array(2)") {
+		t.Fatalf("array detail = %q", sum.Detail)
+	}
+}
+
+func TestDetectJSONL(t *testing.T) {
+	sum := detectSummary([]byte("{\"a\":1}\n{\"a\":2}\n{\"a\":3}"))
+	if sum.Type != "jsonl" || !strings.Contains(sum.Detail, "3 records") {
+		t.Fatalf("jsonl detail = %q type = %q", sum.Detail, sum.Type)
+	}
+}
+
+func TestDetectText(t *testing.T) {
+	sum := detectSummary([]byte("line one\nline two\nplain prose here"))
+	if sum.Type != "text" || !strings.Contains(sum.Detail, "3 lines") {
+		t.Fatalf("text detail = %q type = %q", sum.Detail, sum.Type)
+	}
+}
+
+func TestRenderStub(t *testing.T) {
+	sum := detectSummary([]byte(`{"a":1}`))
+	stub := RenderStub("9f3a1c8e0000", 14200, sum)
+	if !strings.Contains(stub, "9f3a1c8e0000") || !strings.Contains(stub, "~14.2k tok") || !strings.Contains(stub, "type=json") {
+		t.Fatalf("stub = %q", stub)
+	}
+	if !strings.Contains(stub, `retrieve("9f3a1c8e0000")`) {
+		t.Fatalf("stub missing retrieve hint: %q", stub)
+	}
+}
+
+func TestFilterJSONArray(t *testing.T) {
+	content := []byte(`[{"name":"alpha"},{"name":"beta"},{"name":"alphabet"}]`)
+	sum := detectSummary(content)
+	out := FilterContent(content, sum, "alpha")
+	if !strings.Contains(out, "alpha") || !strings.Contains(out, "alphabet") || strings.Contains(out, "beta") {
+		t.Fatalf("filtered array = %q", out)
+	}
+}
+
+func TestFilterTextLines(t *testing.T) {
+	content := []byte("error: boom\ninfo: ok\nerror: bang")
+	sum := detectSummary(content)
+	out := FilterContent(content, sum, "error")
+	if !strings.Contains(out, "boom") || !strings.Contains(out, "bang") || strings.Contains(out, "info: ok") {
+		t.Fatalf("filtered text = %q", out)
+	}
+}
+
+func TestFilterEmptyQueryReturnsAll(t *testing.T) {
+	content := []byte("anything at all")
+	if got := FilterContent(content, detectSummary(content), ""); got != string(content) {
+		t.Fatalf("empty query = %q, want full content", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd pkgs/crumb && go test ./...`
+Expected: compile error (`undefined: EstimateTokens`, `detectSummary`, `RenderStub`, `FilterContent`).
+
+- [ ] **Step 3: Implement `summary.go`**
+
+```go
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// EstimateTokens is a rough heuristic: ceil(chars / 4).
+func EstimateTokens(content []byte) int {
+	return (len(content) + 3) / 4
+}
+
+func humanTokens(n int) string {
+	if n >= 1000 {
+		return fmt.Sprintf("%.1fk", float64(n)/1000.0)
+	}
+	return fmt.Sprintf("%d", n)
+}
+
+// Summary describes detected structure of content.
+type Summary struct {
+	Type    string // "json" | "jsonl" | "text"
+	Detail  string
+	Preview string
+}
+
+func detectSummary(content []byte) Summary {
+	trimmed := strings.TrimSpace(string(content))
+
+	var js interface{}
+	if trimmed != "" && json.Unmarshal([]byte(trimmed), &js) == nil {
+		switch v := js.(type) {
+		case map[string]interface{}:
+			return Summary{Type: "json", Detail: "keys=[" + jsonObjectKeys(v) + "]", Preview: preview(trimmed)}
+		case []interface{}:
+			detail := fmt.Sprintf("array(%d)", len(v))
+			if len(v) > 0 {
+				if first, ok := v[0].(map[string]interface{}); ok {
+					detail += " elem_keys=[" + jsonObjectKeys(first) + "]"
+				}
+			}
+			return Summary{Type: "json", Detail: detail, Preview: preview(trimmed)}
+		default:
+			return Summary{Type: "json", Detail: "scalar", Preview: preview(trimmed)}
+		}
+	}
+
+	lines := strings.Split(trimmed, "\n")
+	jsonlOK := len(lines) > 1
+	count := 0
+	for _, ln := range lines {
+		ln = strings.TrimSpace(ln)
+		if ln == "" {
+			continue
+		}
+		var x interface{}
+		if json.Unmarshal([]byte(ln), &x) != nil {
+			jsonlOK = false
+			break
+		}
+		count++
+	}
+	if jsonlOK && count > 1 {
+		return Summary{Type: "jsonl", Detail: fmt.Sprintf("%d records", count), Preview: preview(trimmed)}
+	}
+
+	nLines := strings.Count(string(content), "\n") + 1
+	return Summary{Type: "text", Detail: fmt.Sprintf("%d lines, %d chars", nLines, len(content)), Preview: preview(trimmed)}
+}
+
+// jsonObjectKeys lists keys (sorted for determinism), annotating array-valued
+// keys with their length, e.g. "meta, page, results(3)".
+func jsonObjectKeys(m map[string]interface{}) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		if arr, ok := m[k].([]interface{}); ok {
+			parts = append(parts, fmt.Sprintf("%s(%d)", k, len(arr)))
+		} else {
+			parts = append(parts, k)
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+func preview(s string) string {
+	const max = 160
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len(s) > max {
+		return s[:max] + " …"
+	}
+	return s
+}
+
+// RenderStub builds the transcript stub for stored content.
+func RenderStub(hash string, origTok int, sum Summary) string {
+	return fmt.Sprintf("⟦crumb %s ~%s tok type=%s %s⟧\npreview: %s\n↳ retrieve(%q) for full content",
+		hash, humanTokens(origTok), sum.Type, sum.Detail, sum.Preview, hash)
+}
+
+// FilterContent returns the parts of content matching query. JSON arrays are
+// filtered element-wise; text/jsonl/objects are grepped line-wise. An empty
+// query returns the full content.
+func FilterContent(content []byte, sum Summary, query string) string {
+	if query == "" {
+		return string(content)
+	}
+	if sum.Type == "json" {
+		var arr []json.RawMessage
+		if json.Unmarshal(content, &arr) == nil {
+			var matched []string
+			for _, el := range arr {
+				if strings.Contains(string(el), query) {
+					matched = append(matched, string(el))
+				}
+			}
+			return fmt.Sprintf("[%s]\n(%d of %d elements matched %q)",
+				strings.Join(matched, ", "), len(matched), len(arr), query)
+		}
+		// not an array (object/scalar) — fall through to line grep
+	}
+	var out []string
+	for _, ln := range strings.Split(string(content), "\n") {
+		if strings.Contains(ln, query) {
+			out = append(out, ln)
+		}
+	}
+	return fmt.Sprintf("%s\n(%d lines matched %q)", strings.Join(out, "\n"), len(out), query)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd pkgs/crumb && go test ./...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/nixos/wkspace/worktree/feat/crumb
+jj commit -m ":sparkles: feat(crumb): heuristic summary, stub rendering, query filter"
+```
+
+---
+
+### Task 5: Orchestration core — CompressContent / RetrieveContent / StatsText / dispatchTool
+
+**Files:**
+- Create: `pkgs/crumb/ops.go`
+- Test: `pkgs/crumb/ops_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestCompressStoresAndStubs(t *testing.T) {
+	s := newTestStore(t)
+	big := []byte(strings.Repeat("x", 4000)) // ~1000 tokens, above min
+	stub, err := CompressContent(s, big, 1)
+	if err != nil {
+		t.Fatalf("CompressContent: %v", err)
+	}
+	if !strings.HasPrefix(stub, "⟦crumb ") {
+		t.Fatalf("expected a stub, got %q", stub)
+	}
+	// the stub must carry a retrievable hash
+	start := strings.Index(stub, "⟦crumb ") + len("⟦crumb ")
+	hash := stub[start : start+12]
+	got, err := s.Get(hash)
+	if err != nil || string(got) != string(big) {
+		t.Fatalf("retrieve via stub hash failed: err=%v len=%d", err, len(got))
+	}
+}
+
+func TestCompressSmallPassesThrough(t *testing.T) {
+	s := newTestStore(t)
+	small := []byte("tiny")
+	out, err := CompressContent(s, small, 1)
+	if err != nil {
+		t.Fatalf("CompressContent: %v", err)
+	}
+	if out != "tiny" {
+		t.Fatalf("small content should pass through unchanged, got %q", out)
+	}
+}
+
+func TestRetrieveNotFound(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := RetrieveContent(s, "nope00000000", ""); err != ErrNotFound {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestStatsTextReportsSaved(t *testing.T) {
+	s := newTestStore(t)
+	CompressContent(s, []byte(strings.Repeat("y", 4000)), 1)
+	out, err := StatsText(s)
+	if err != nil {
+		t.Fatalf("StatsText: %v", err)
+	}
+	if !strings.Contains(out, "saved=") || !strings.Contains(out, "compressions: 1") {
+		t.Fatalf("stats text = %q", out)
+	}
+}
+
+func TestDispatchToolCompress(t *testing.T) {
+	s := newTestStore(t)
+	args := json.RawMessage(`{"content":` + jsonString(strings.Repeat("z", 4000)) + `}`)
+	out, err := dispatchTool("compress", args, s)
+	if err != nil || !strings.HasPrefix(out, "⟦crumb ") {
+		t.Fatalf("dispatch compress: out=%q err=%v", out, err)
+	}
+}
+
+func jsonString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd pkgs/crumb && go test ./...`
+Expected: compile error (`undefined: CompressContent`, `RetrieveContent`, `StatsText`, `dispatchTool`).
+
+- [ ] **Step 3: Implement `ops.go`**
+
+```go
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func minTokens() int {
+	if v := os.Getenv("CRUMB_MIN_TOKENS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			return n
+		}
+	}
+	return 50
+}
+
+func pricePerMTok() float64 {
+	if v := os.Getenv("CRUMB_PRICE_PER_MTOK"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
+			return f
+		}
+	}
+	return 0
+}
+
+// CompressContent stores content and returns a stub. Content below the min-token
+// threshold is returned unchanged (no store, no event).
+func CompressContent(store *Store, content []byte, ts int64) (string, error) {
+	origTok := EstimateTokens(content)
+	if origTok < minTokens() {
+		return string(content), nil
+	}
+	hash, err := store.Put(content)
+	if err != nil {
+		return "", err
+	}
+	sum := detectSummary(content)
+	stub := RenderStub(hash, origTok, sum)
+	stubTok := EstimateTokens([]byte(stub))
+	_ = store.AppendEvent(Event{TS: ts, Op: "compress", Hash: hash, OrigTok: origTok, StubTok: stubTok})
+	return stub, nil
+}
+
+// RetrieveContent reads stored content for hash, optionally filtered by query.
+func RetrieveContent(store *Store, hash, query string) (string, error) {
+	data, err := store.Get(hash)
+	if err != nil {
+		return "", err
+	}
+	return FilterContent(data, detectSummary(data), query), nil
+}
+
+// StatsText renders human-readable savings for the store.
+func StatsText(store *Store) (string, error) {
+	st, err := store.ReadStats(10)
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "crumb store: %s\n", store.dir)
+	fmt.Fprintf(&b, "compressions: %d\n", st.Compressions)
+	fmt.Fprintf(&b, "unique blobs: %d\n", st.UniqueBlobs)
+	fmt.Fprintf(&b, "tokens: orig=%d stub=%d saved=%d\n", st.OrigTokens, st.StubTokens, st.SavedTokens)
+	fmt.Fprintf(&b, "store size: %.2f MB\n", float64(st.StoreBytes)/(1024*1024))
+	if price := pricePerMTok(); price > 0 {
+		fmt.Fprintf(&b, "est cost saved: $%.4f (at $%.2f/Mtok)\n", float64(st.SavedTokens)/1e6*price, price)
+	}
+	if len(st.Recent) > 0 {
+		b.WriteString("recent:\n")
+		for _, e := range st.Recent {
+			fmt.Fprintf(&b, "  %s %s orig=%d stub=%d\n", e.Op, e.Hash, e.OrigTok, e.StubTok)
+		}
+	}
+	return b.String(), nil
+}
+
+// dispatchTool routes an MCP/CLI tool call to the core operations. Shared by the
+// MCP server and (indirectly) the CLI, so the two can never diverge.
+func dispatchTool(name string, args json.RawMessage, store *Store) (string, error) {
+	switch name {
+	case "compress":
+		var a struct {
+			Content string `json:"content"`
+		}
+		if err := json.Unmarshal(args, &a); err != nil {
+			return "", fmt.Errorf("invalid arguments for compress: %w", err)
+		}
+		return CompressContent(store, []byte(a.Content), time.Now().Unix())
+	case "retrieve":
+		var a struct {
+			Hash  string `json:"hash"`
+			Query string `json:"query"`
+		}
+		if err := json.Unmarshal(args, &a); err != nil {
+			return "", fmt.Errorf("invalid arguments for retrieve: %w", err)
+		}
+		return RetrieveContent(store, a.Hash, a.Query)
+	case "stats":
+		return StatsText(store)
+	default:
+		return "", fmt.Errorf("unknown tool: %s", name)
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd pkgs/crumb && go test ./...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/nixos/wkspace/worktree/feat/crumb
+jj commit -m ":sparkles: feat(crumb): compress/retrieve/stats orchestration + tool dispatch"
+```
+
+---
+
+### Task 6: MCP JSON-RPC stdio server
+
+**Files:**
+- Create: `pkgs/crumb/mcp.go`
+- Test: `pkgs/crumb/mcp_test.go`
+
+- [ ] **Step 1: Write the failing protocol tests**
+
+```go
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// runRPC feeds newline-delimited request lines through ServeMCP and returns the
+// decoded response objects (notifications produce no line).
+func runRPC(t *testing.T, store *Store, requests ...string) []map[string]interface{} {
+	t.Helper()
+	in := strings.NewReader(strings.Join(requests, "\n") + "\n")
+	var out bytes.Buffer
+	if err := ServeMCP(in, &out, store); err != nil {
+		t.Fatalf("ServeMCP: %v", err)
+	}
+	var resps []map[string]interface{}
+	for _, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatalf("bad response line %q: %v", line, err)
+		}
+		resps = append(resps, m)
+	}
+	return resps
+}
+
+func TestMCPInitialize(t *testing.T) {
+	s := newTestStore(t)
+	r := runRPC(t, s, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18"}}`)
+	if len(r) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(r))
+	}
+	res := r[0]["result"].(map[string]interface{})
+	if res["protocolVersion"] != "2025-06-18" {
+		t.Fatalf("protocolVersion not echoed: %v", res["protocolVersion"])
+	}
+	if res["serverInfo"].(map[string]interface{})["name"] != "crumb" {
+		t.Fatalf("serverInfo.name wrong: %v", res["serverInfo"])
+	}
+}
+
+func TestMCPNotificationNoResponse(t *testing.T) {
+	s := newTestStore(t)
+	r := runRPC(t, s, `{"jsonrpc":"2.0","method":"notifications/initialized"}`)
+	if len(r) != 0 {
+		t.Fatalf("notification must produce no response, got %d", len(r))
+	}
+}
+
+func TestMCPToolsList(t *testing.T) {
+	s := newTestStore(t)
+	r := runRPC(t, s, `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`)
+	tools := r[0]["result"].(map[string]interface{})["tools"].([]interface{})
+	if len(tools) != 3 {
+		t.Fatalf("expected 3 tools, got %d", len(tools))
+	}
+	names := map[string]bool{}
+	for _, tl := range tools {
+		names[tl.(map[string]interface{})["name"].(string)] = true
+	}
+	for _, want := range []string{"compress", "retrieve", "stats"} {
+		if !names[want] {
+			t.Fatalf("missing tool %q in %v", want, names)
+		}
+	}
+}
+
+func TestMCPToolsCallCompressThenRetrieve(t *testing.T) {
+	s := newTestStore(t)
+	big := strings.Repeat("Q", 4000)
+	bigJSON, _ := json.Marshal(big)
+	r := runRPC(t, s,
+		`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"compress","arguments":{"content":`+string(bigJSON)+`}}}`)
+	content := r[0]["result"].(map[string]interface{})["content"].([]interface{})
+	stub := content[0].(map[string]interface{})["text"].(string)
+	if !strings.HasPrefix(stub, "⟦crumb ") {
+		t.Fatalf("compress did not return a stub: %q", stub)
+	}
+}
+
+func TestMCPUnknownMethod(t *testing.T) {
+	s := newTestStore(t)
+	r := runRPC(t, s, `{"jsonrpc":"2.0","id":9,"method":"does/not/exist"}`)
+	if r[0]["error"] == nil {
+		t.Fatalf("expected error for unknown method")
+	}
+	code := r[0]["error"].(map[string]interface{})["code"].(float64)
+	if int(code) != -32601 {
+		t.Fatalf("error code = %v, want -32601", code)
+	}
+}
+
+func TestMCPParseError(t *testing.T) {
+	s := newTestStore(t)
+	r := runRPC(t, s, `{not valid json`)
+	if r[0]["error"].(map[string]interface{})["code"].(float64) != -32700 {
+		t.Fatalf("expected parse error -32700")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd pkgs/crumb && go test ./...`
+Expected: compile error (`undefined: ServeMCP`).
+
+- [ ] **Step 3: Implement `mcp.go`**
+
+```go
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+)
+
+// serverProtocolVersion is used when the client does not request one.
+const serverProtocolVersion = "2025-06-18"
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  interface{}     `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// ServeMCP runs the newline-delimited JSON-RPC stdio loop until in is exhausted.
+// Only JSON responses are written to out; nothing else may touch it.
+func ServeMCP(in io.Reader, out io.Writer, store *Store) error {
+	sc := bufio.NewScanner(in)
+	sc.Buffer(make([]byte, 1024*1024), 64*1024*1024)
+	enc := json.NewEncoder(out)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var req rpcRequest
+		if json.Unmarshal(line, &req) != nil {
+			if err := enc.Encode(rpcResponse{JSONRPC: "2.0", Error: &rpcError{Code: -32700, Message: "parse error"}}); err != nil {
+				return err
+			}
+			continue
+		}
+		resp, isNotification := handleRPC(&req, store)
+		if isNotification {
+			continue
+		}
+		if err := enc.Encode(resp); err != nil {
+			return err
+		}
+	}
+	return sc.Err()
+}
+
+func handleRPC(req *rpcRequest, store *Store) (rpcResponse, bool) {
+	switch req.Method {
+	case "initialize":
+		pv := serverProtocolVersion
+		var p struct {
+			ProtocolVersion string `json:"protocolVersion"`
+		}
+		if json.Unmarshal(req.Params, &p) == nil && p.ProtocolVersion != "" {
+			pv = p.ProtocolVersion
+		}
+		return rpcResponse{
+			JSONRPC: "2.0", ID: req.ID,
+			Result: map[string]interface{}{
+				"protocolVersion": pv,
+				"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+				"serverInfo":      map[string]interface{}{"name": "crumb", "version": version},
+			},
+		}, false
+	case "notifications/initialized":
+		return rpcResponse{}, true
+	case "ping":
+		return rpcResponse{JSONRPC: "2.0", ID: req.ID, Result: map[string]interface{}{}}, false
+	case "tools/list":
+		return rpcResponse{JSONRPC: "2.0", ID: req.ID, Result: map[string]interface{}{"tools": toolDefs()}}, false
+	case "tools/call":
+		return handleToolCall(req, store), false
+	default:
+		if req.ID == nil { // any other notification
+			return rpcResponse{}, true
+		}
+		return rpcResponse{JSONRPC: "2.0", ID: req.ID, Error: &rpcError{Code: -32601, Message: "method not found: " + req.Method}}, false
+	}
+}
+
+func handleToolCall(req *rpcRequest, store *Store) rpcResponse {
+	var p struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	}
+	if json.Unmarshal(req.Params, &p) != nil {
+		return rpcResponse{JSONRPC: "2.0", ID: req.ID, Error: &rpcError{Code: -32602, Message: "invalid params"}}
+	}
+	text, err := dispatchTool(p.Name, p.Arguments, store)
+	if err != nil {
+		return rpcResponse{JSONRPC: "2.0", ID: req.ID, Error: &rpcError{Code: -32602, Message: err.Error()}}
+	}
+	return rpcResponse{JSONRPC: "2.0", ID: req.ID, Result: map[string]interface{}{
+		"content": []map[string]interface{}{{"type": "text", "text": text}},
+	}}
+}
+
+func toolDefs() []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"name":        "compress",
+			"description": "Store large content out of context and return a short crumb stub (hash + summary). Use on big tool outputs, file contents, logs, or search results; retrieve the original later with the retrieve tool.",
+			"inputSchema": map[string]interface{}{
+				"type":     "object",
+				"required": []string{"content"},
+				"properties": map[string]interface{}{
+					"content": map[string]interface{}{"type": "string", "description": "The content to stash."},
+				},
+			},
+		},
+		{
+			"name":        "retrieve",
+			"description": "Retrieve previously stored content by its crumb hash. An optional query filters JSON array elements or text lines.",
+			"inputSchema": map[string]interface{}{
+				"type":     "object",
+				"required": []string{"hash"},
+				"properties": map[string]interface{}{
+					"hash":  map[string]interface{}{"type": "string", "description": "The crumb hash from a compress result."},
+					"query": map[string]interface{}{"type": "string", "description": "Optional filter string."},
+				},
+			},
+		},
+		{
+			"name":        "stats",
+			"description": "Show crumb savings for this store: compressions, tokens saved, store size, and recent events.",
+			"inputSchema": map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
+			},
+		},
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd pkgs/crumb && go test ./...`
+Expected: PASS (all tests across all files).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/nixos/wkspace/worktree/feat/crumb
+jj commit -m ":sparkles: feat(crumb): MCP JSON-RPC stdio server (3 tools)"
+```
+
+---
+
+### Task 7: Wire the CLI subcommands
+
+**Files:**
+- Modify: `pkgs/crumb/main.go` (add subcommands; keep existing version/help)
+
+- [ ] **Step 1: Replace `main.go` with the full CLI**
+
+```go
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// version is overridden at build time via -ldflags "-X main.version=…".
+var version = "dev"
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+	switch os.Args[1] {
+	case "mcp", "serve":
+		runMCP()
+	case "compress":
+		runCompress(os.Args[2:])
+	case "retrieve":
+		runRetrieve(os.Args[2:])
+	case "stats":
+		runStats(os.Args[2:])
+	case "gc":
+		runGC(os.Args[2:])
+	case "--version", "-v", "version":
+		fmt.Println("crumb", version)
+	case "--help", "-h", "help":
+		usage()
+	default:
+		fmt.Fprintln(os.Stderr, "unknown command:", os.Args[1])
+		usage()
+		os.Exit(2)
+	}
+}
+
+func openStore() *Store {
+	s, err := NewStore(DefaultDir())
+	check(err)
+	return s
+}
+
+func runMCP() {
+	if err := ServeMCP(os.Stdin, os.Stdout, openStore()); err != nil {
+		fmt.Fprintln(os.Stderr, "crumb mcp:", err)
+		os.Exit(1)
+	}
+}
+
+func runCompress(args []string) {
+	var data []byte
+	var err error
+	if len(args) == 0 || args[0] == "-" {
+		data, err = io.ReadAll(os.Stdin)
+	} else {
+		data, err = os.ReadFile(args[0])
+	}
+	check(err)
+	out, err := CompressContent(openStore(), data, time.Now().Unix())
+	check(err)
+	fmt.Println(out)
+}
+
+func runRetrieve(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: crumb retrieve <hash> [--query Q]")
+		os.Exit(2)
+	}
+	hash := args[0]
+	query := ""
+	for i := 1; i < len(args); i++ {
+		if args[i] == "--query" && i+1 < len(args) {
+			query = args[i+1]
+			i++
+		}
+	}
+	out, err := RetrieveContent(openStore(), hash, query)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Print(out)
+	if !strings.HasSuffix(out, "\n") {
+		fmt.Println()
+	}
+}
+
+func runStats(args []string) {
+	out, err := StatsText(openStore())
+	check(err)
+	fmt.Print(out)
+}
+
+func runGC(args []string) {
+	days := envInt("CRUMB_GC_DAYS", 14)
+	maxMB := envInt("CRUMB_GC_MAX_MB", 512)
+	all := false
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--days":
+			if i+1 < len(args) {
+				days = atoiOr(args[i+1], days)
+				i++
+			}
+		case "--max-mb":
+			if i+1 < len(args) {
+				maxMB = atoiOr(args[i+1], maxMB)
+				i++
+			}
+		case "--all":
+			all = true
+		}
+	}
+	store := openStore()
+	var res GCResult
+	var err error
+	if all {
+		res, err = store.GC(time.Now(), time.Nanosecond, 0) // evict everything
+	} else {
+		res, err = store.GC(time.Now(), time.Duration(days)*24*time.Hour, int64(maxMB)*1024*1024)
+	}
+	check(err)
+	fmt.Printf("crumb gc: removed %d blob(s), freed %.2f MB\n", res.Removed, float64(res.FreedBytes)/(1024*1024))
+}
+
+func envInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		return atoiOr(v, def)
+	}
+	return def
+}
+
+func atoiOr(s string, def int) int {
+	if n, err := strconv.Atoi(s); err == nil {
+		return n
+	}
+	return def
+}
+
+func check(err error) {
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "crumb:", err)
+		os.Exit(1)
+	}
+}
+
+func usage() {
+	fmt.Fprint(os.Stderr, `crumb — context store-and-stub
+
+usage:
+  crumb mcp                          run the stdio MCP server
+  crumb compress [FILE|-]            store content, print the crumb stub
+  crumb retrieve <hash> [--query Q]  print stored content (optionally filtered)
+  crumb stats                        print savings + recent events
+  crumb gc [--days N] [--max-mb M] [--all]   prune old/oversized blobs
+  crumb --version | --help
+
+env:
+  CRUMB_DIR             store directory (default ~/.local/state/crumb)
+  CRUMB_MIN_TOKENS      don't stub content below this (default 50)
+  CRUMB_HASH_LEN        short-hash length (default 12)
+  CRUMB_GC_DAYS         gc age in days (default 14)
+  CRUMB_GC_MAX_MB       gc size cap in MB (default 512)
+  CRUMB_PRICE_PER_MTOK  if set, stats shows estimated cost saved
+`)
+}
+```
+
+- [ ] **Step 2: Verify a full CLI roundtrip by hand**
+
+Run:
+```bash
+cd /home/nixos/wkspace/worktree/feat/crumb/pkgs/crumb
+export CRUMB_DIR="$(mktemp -d)"
+go build -o /tmp/crumb . && \
+printf '{"results":[%s],"meta":{"page":1}}' "$(seq -s, 1 500)" | /tmp/crumb compress | tee /tmp/stub.txt
+HASH=$(sed -n 's/^⟦crumb \([a-f0-9]*\) .*/\1/p' /tmp/stub.txt)
+echo "hash=$HASH"
+/tmp/crumb retrieve "$HASH" | head -c 80; echo
+/tmp/crumb stats
+```
+Expected: `compress` prints a `⟦crumb …⟧` stub; `retrieve` prints the original JSON; `stats` shows `compressions: 1` and a positive `saved=`.
+
+- [ ] **Step 3: Run the whole test suite**
+
+Run: `cd pkgs/crumb && go vet ./... && go test ./...`
+Expected: `go vet` clean, all tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/nixos/wkspace/worktree/feat/crumb
+jj commit -m ":sparkles: feat(crumb): CLI subcommands (compress/retrieve/stats/gc/mcp)"
+```
+
+---
+
+### Task 8: Nix package (`default.nix`) — build + run tests under Nix
+
+**Files:**
+- Create: `pkgs/crumb/default.nix`
+
+- [ ] **Step 1: Write `default.nix`**
+
+```nix
+{ buildGoModule, lib }:
+
+buildGoModule {
+  pname = "crumb";
+  version = "0.1.0";
+
+  src = ./.;
+
+  # No third-party modules — the whole tool is Go standard library.
+  vendorHash = null;
+
+  # Run `go test ./...` in the check phase so `nix build`/`nix flake check`
+  # exercise the unit + protocol tests.
+  doCheck = true;
+
+  ldflags = [ "-s" "-w" "-X main.version=0.1.0" ];
+
+  meta = {
+    description = "Zero-dependency context store-and-stub: MCP server + CLI";
+    longDescription = ''
+      crumb stores large content out of an agent's context window (content-addressed,
+      locally) and returns a short stub the agent can follow back with the retrieve
+      tool. Pure Go standard library; no ML, no network, no telemetry.
+    '';
+    mainProgram = "crumb";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+  };
+}
+```
+
+- [ ] **Step 2: Build under Nix from the repo root (the overlay isn't wired yet, so build directly)**
+
+Run:
+```bash
+cd /home/nixos/wkspace/worktree/feat/crumb
+nix-build -E 'with import <nixpkgs> {}; callPackage ./pkgs/crumb {}' --no-out-link
+```
+Expected: build succeeds and runs `go test ./...` during the check phase (look for `ok crumb` test output), producing a `crumb` binary in the store.
+
+> If `<nixpkgs>` is unavailable in this shell, defer this verification to Task 9's `nix flake check`, which builds `pkgs.crumb` via the flake. Note that here in the plan and move on.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/nixos/wkspace/worktree/feat/crumb
+jj commit -m ":sparkles: feat(crumb): buildGoModule package (vendorHash=null, tests in checkPhase)"
+```
+
+---
+
+## Phase 2 — Nix integration & headroom purge
+
+### Task 9: flake.nix — drop headroom input/overlay, add crumb overlay + check
+
+**Files:**
+- Modify: `flake.nix`
+
+- [ ] **Step 1: Remove the headroom flake input**
+
+Delete this block (lines ~36–39):
+
+```nix
+    # headroom context-compression MCP server (native binary via Cachix)
+    headroom = {
+      url = "github:LITl-l/headroom-overlay";
+    };
+```
+
+- [ ] **Step 2: Replace the overlays list (drop the Linux-gated headroom overlay, add crumb)**
+
+Replace:
+
+```nix
+        overlays = [
+          inputs.claude-code.overlays.default
+          inputs.pi.overlays.default
+        ] ++ nixpkgs.lib.optionals (system == "x86_64-linux") [
+          # headroom-overlay only publishes x86_64-linux; gate it so the
+          # darwin/aarch64 configs (and `nix flake check`) still evaluate.
+          inputs.headroom.overlays.default
+        ];
+```
+
+with:
+
+```nix
+        overlays = [
+          inputs.claude-code.overlays.default
+          inputs.pi.overlays.default
+          # crumb: in-repo context store-and-stub (pure-Go, builds on all platforms).
+          (final: _prev: { crumb = final.callPackage ./pkgs/crumb { }; })
+        ];
+```
+
+- [ ] **Step 3: Add a flake check that builds crumb (running its Go tests)**
+
+Inside the `checks = forAllSystems (system: … in { … } // linuxChecks);` block, add `crumb-tests` to the always-present checks (the `in { … }` set, e.g. right after the `pi-subagents-tests` attribute and before the closing `} // linuxChecks`):
+
+```nix
+          crumb-tests = pkgs.crumb;
+```
+
+(`pkgs.crumb` is a derivation whose `checkPhase` runs `go test ./...`, so building it as a check exercises the suite on `nix flake check`.)
+
+- [ ] **Step 4: Verify the flake evaluates and crumb builds + tests pass**
+
+Run:
+```bash
+cd /home/nixos/wkspace/worktree/feat/crumb
+nix flake check 2>&1 | tail -30
+```
+Expected: no evaluation errors; `crumb-tests` builds (Go tests run in checkPhase). If `nix flake check` is slow, first sanity-check with `nix build .#checks.x86_64-linux.crumb-tests -L`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/nixos/wkspace/worktree/feat/crumb
+jj commit -m ":heavy_minus_sign: chore(flake): replace headroom input/overlay with in-repo crumb"
+```
+
+---
+
+### Task 10: home.nix — swap package, remove telemetry env + cachix comments
+
+**Files:**
+- Modify: `home.nix`
+
+- [ ] **Step 1: Replace the package entry (move crumb into the main list, drop the Linux-gated headroom block)**
+
+Replace:
+
+```nix
+    nix-manager # Custom nix-manager command
+  ] ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+    # headroom-ai context-compression CLI + MCP server (via LITl-l/headroom-overlay).
+    # Linux-guarded: the overlay only publishes x86_64-linux. pkgs.headroom is
+    # fully qualified because this append is outside the `with pkgs;` scope above.
+    pkgs.headroom
+  ];
+```
+
+with:
+
+```nix
+    nix-manager # Custom nix-manager command
+
+    # crumb: in-repo, zero-dependency context store-and-stub (MCP server + CLI).
+    # Pure-Go static binary built from ./pkgs/crumb; replaces headroom-ai.
+    crumb
+  ];
+```
+
+- [ ] **Step 2: Remove the `HEADROOM_TELEMETRY` session variable**
+
+Delete this block from `home.sessionVariables` (lines ~86–95, including the blank line after it):
+
+```nix
+    # Opt out of headroom-ai's on-by-default telemetry. Its TelemetryBeacon
+    # (site-packages/headroom/telemetry/beacon.py) otherwise POSTs anonymous
+    # aggregate stats — plus a SHA256(hostname) machine fingerprint — to a
+    # hardcoded Supabase endpoint every 5 minutes. This is headroom's documented
+    # kill-switch; collector.py honours it too (gates the /v1/telemetry report).
+    # Set at session scope so the `headroom` CLI *and* the MCP servers (which
+    # inherit this env) are covered; also baked into each MCP registration as
+    # defense-in-depth (see modules/claude-code.nix and modules/pi.nix).
+    HEADROOM_TELEMETRY = "off";
+
+```
+
+- [ ] **Step 3: Remove the headroom cachix comment in `nix.conf`**
+
+Delete these three comment lines (lines ~118–120):
+
+```nix
+      # headroom-overlay cachix cache (deferred): once the cache + public key exist,
+      # append " https://headroom-overlay.cachix.org" to extra-substituters above and
+      # " headroom-overlay.cachix.org-1:<KEY>" to extra-trusted-public-keys above.
+```
+
+- [ ] **Step 4: Verify it evaluates**
+
+Run:
+```bash
+cd /home/nixos/wkspace/worktree/feat/crumb
+nix eval .#homeConfigurations.\"nixos@wsl\".config.home.packages --apply 'ps: builtins.any (p: (p.pname or p.name or "") == "crumb") ps' 2>&1 | tail -5
+```
+Expected: prints `true` (crumb is in the package set). No eval errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/nixos/wkspace/worktree/feat/crumb
+jj commit -m ":wrench: chore(home): use pkgs.crumb, drop headroom telemetry env + cachix notes"
+```
+
+---
+
+### Task 11: modules/pi.nix — re-register MCP server as crumb
+
+**Files:**
+- Modify: `modules/pi.nix`
+
+- [ ] **Step 1: Replace the headroom MCP registration**
+
+Replace (lines ~31–50):
+
+```nix
+  # Register headroom-ai's context-compression MCP server (stdio transport). Pi
+  # reads ~/.pi/agent/mcp.json. lifecycle "lazy" means Pi only spawns the server
+  # when a headroom_* tool is actually invoked. headroom is on PATH on Linux via
+  # home.packages (LITl-l/headroom-overlay).
+  #
+  # env HEADROOM_TELEMETRY=off disables headroom's on-by-default Supabase
+  # telemetry beacon for this server regardless of the inherited environment
+  # (mirrors the session var in home.nix and the Claude registration).
+  home.file.".pi/agent/mcp.json".text = ''
+    {
+      "mcpServers": {
+        "headroom": {
+          "command": "headroom",
+          "args": ["mcp", "serve"],
+          "env": { "HEADROOM_TELEMETRY": "off" },
+          "lifecycle": "lazy"
+        }
+      }
+    }
+  '';
+```
+
+with:
+
+```nix
+  # Register crumb's context store-and-stub MCP server (stdio transport). Pi reads
+  # ~/.pi/agent/mcp.json. lifecycle "lazy" means Pi only spawns the server when a
+  # crumb tool is actually invoked. crumb is on PATH via home.packages and has no
+  # telemetry, so no opt-out env is needed.
+  home.file.".pi/agent/mcp.json".text = ''
+    {
+      "mcpServers": {
+        "crumb": {
+          "command": "crumb",
+          "args": ["mcp"],
+          "lifecycle": "lazy"
+        }
+      }
+    }
+  '';
+```
+
+- [ ] **Step 2: Verify the rendered mcp.json is valid JSON**
+
+Run:
+```bash
+cd /home/nixos/wkspace/worktree/feat/crumb
+nix eval --raw .#homeConfigurations.\"nixos@wsl\".config.home.file.\".pi/agent/mcp.json\".text 2>/dev/null | jq .
+```
+Expected: pretty-prints JSON with a `crumb` server, `"args": ["mcp"]`, no `env`/`headroom`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/nixos/wkspace/worktree/feat/crumb
+jj commit -m ":wrench: chore(pi): register crumb MCP server, drop headroom"
+```
+
+---
+
+### Task 12: modules/claude-code.nix — register crumb, remove headroom
+
+**Files:**
+- Modify: `modules/claude-code.nix`
+
+- [ ] **Step 1: Replace the `registerHeadroomMcp` activation block**
+
+Replace (lines ~23–43):
+
+```nix
+  # Register headroom-ai's stdio MCP server with Claude Code at user scope. MCP
+  # servers live in the stateful ~/.claude.json, so we delegate the file
+  # location/format to the `claude` CLI rather than managing it declaratively.
+  #
+  # `claude` is invoked by absolute store path because the new generation's bin/
+  # is not on PATH during activation; `headroom` is registered as a *bare*
+  # command (resolved from PATH when Claude launches it), which keeps the entry
+  # stable across headroom updates.
+  #
+  # HEADROOM_TELEMETRY=off is baked into the registration to disable headroom's
+  # on-by-default Supabase telemetry beacon for this MCP server (it also inherits
+  # the session var from home.nix; this is belt-and-suspenders). The guard greps
+  # the entry's Environment for HEADROOM_TELEMETRY so an existing env-less
+  # registration (added before this change) is reconciled exactly once: when the
+  # var is absent we remove + re-add with it; when already present we no-op.
+  home.activation.registerHeadroomMcp = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    if ! ${pkgs.claude-code}/bin/claude mcp get headroom 2>/dev/null | grep -q HEADROOM_TELEMETRY; then
+      ${pkgs.claude-code}/bin/claude mcp remove headroom -s user >/dev/null 2>&1 || true
+      ${pkgs.claude-code}/bin/claude mcp add headroom -s user -e HEADROOM_TELEMETRY=off -- headroom mcp serve >/dev/null 2>&1 || true
+    fi
+  '';
+```
+
+with:
+
+```nix
+  # Register crumb's stdio MCP server with Claude Code at user scope. MCP servers
+  # live in the stateful ~/.claude.json, so we delegate the file location/format to
+  # the `claude` CLI rather than managing it declaratively.
+  #
+  # `claude` is invoked by absolute store path because the new generation's bin/ is
+  # not on PATH during activation; `crumb` is registered as a *bare* command
+  # (resolved from PATH when Claude launches it), which keeps the entry stable
+  # across crumb updates. crumb has no telemetry, so no env is baked in.
+  #
+  # The guard first removes any legacy `headroom` registration, then adds `crumb`
+  # only when it is not already registered, so activation stays idempotent.
+  home.activation.registerCrumbMcp = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    ${pkgs.claude-code}/bin/claude mcp remove headroom -s user >/dev/null 2>&1 || true
+    if ! ${pkgs.claude-code}/bin/claude mcp get crumb >/dev/null 2>&1; then
+      ${pkgs.claude-code}/bin/claude mcp add crumb -s user -- crumb mcp >/dev/null 2>&1 || true
+    fi
+  '';
+```
+
+- [ ] **Step 2: Verify it evaluates**
+
+Run:
+```bash
+cd /home/nixos/wkspace/worktree/feat/crumb
+nix eval --raw .#homeConfigurations.\"nixos@wsl\".config.home.activation.registerCrumbMcp.data 2>/dev/null | grep -c "mcp add crumb"
+```
+Expected: prints `1`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/nixos/wkspace/worktree/feat/crumb
+jj commit -m ":wrench: chore(claude): register crumb MCP server, remove headroom"
+```
+
+---
+
+### Task 13: Purge verification — no headroom left in the tracked repo
+
+**Files:** none (verification + fix-ups only)
+
+- [ ] **Step 1: Grep the tracked tree for any remaining functional headroom reference**
+
+Run:
+```bash
+cd /home/nixos/wkspace/worktree/feat/crumb
+grep -rni "headroom" . \
+  --include="*.nix" --include="*.json" --include="*.fish" --include="*.ts" \
+  2>/dev/null | grep -v -E "docs/superpowers/(specs|plans)/2026-06-03-crumb"
+```
+Expected: **no output**. (The only allowed matches are inside the crumb spec/plan, which mention headroom as historical context; those are excluded above.)
+
+- [ ] **Step 2: If anything else matches, fix it**
+
+For each unexpected match, open the file and remove/replace the headroom reference following the same pattern as Tasks 9–12 (swap to `crumb`, or delete if obsolete). Re-run Step 1 until it is empty.
+
+- [ ] **Step 3: Confirm crumb is wired in all four integration points**
+
+Run:
+```bash
+cd /home/nixos/wkspace/worktree/feat/crumb
+grep -rl "crumb" flake.nix home.nix modules/pi.nix modules/claude-code.nix
+```
+Expected: all four files listed.
+
+- [ ] **Step 4: Commit (only if Step 2 changed files; otherwise skip)**
+
+```bash
+cd /home/nixos/wkspace/worktree/feat/crumb
+jj commit -m ":fire: chore: remove residual headroom references"
+```
+
+---
+
+## Phase 3 — System verification & handoff
+
+### Task 14: Full system verification
+
+**Files:** none (runs the real toolchain)
+
+- [ ] **Step 1: Flake check (builds crumb + runs Go tests + all existing checks)**
+
+Run:
+```bash
+cd /home/nixos/wkspace/worktree/feat/crumb
+nix flake check -L 2>&1 | tail -40
+```
+Expected: all checks pass, including `crumb-tests`.
+
+- [ ] **Step 2: Apply the Home Manager config**
+
+> This mutates the live system. Confirm with the user before running if unsure.
+
+Run:
+```bash
+cd /home/nixos/wkspace/worktree/feat/crumb
+home-manager switch --flake .#"nixos@wsl" 2>&1 | tail -30
+```
+Expected: switch completes; `registerCrumbMcp` activation runs without error.
+
+- [ ] **Step 3: Confirm the live MCP registration and PATH binary**
+
+Run:
+```bash
+claude mcp get crumb
+claude mcp get headroom 2>&1 || echo "headroom: not registered (expected)"
+command -v crumb && crumb --version
+```
+Expected: `crumb` is registered (command `crumb mcp`); `headroom` is **not** registered; `crumb` resolves on PATH and prints its version.
+
+- [ ] **Step 4: Live store roundtrip**
+
+Run:
+```bash
+printf '{"items":[%s]}' "$(seq -s, 1 800)" | crumb compress | tee /tmp/crumb-stub.txt
+H=$(sed -n 's/^⟦crumb \([a-f0-9]*\) .*/\1/p' /tmp/crumb-stub.txt)
+crumb retrieve "$H" | head -c 60; echo
+crumb retrieve "$H" --query 5 | head -c 120; echo
+crumb stats
+```
+Expected: a stub is printed; `retrieve` returns the original JSON; `--query 5` filters; `stats` shows a positive `saved=`.
+
+- [ ] **Step 5: Update the local telemetry memory (local file — not part of the PR)**
+
+The memory lives outside the repo at
+`/home/nixos/.claude/projects/-home-nixos--config-dotfiles/memory/feedback_audit_tool_telemetry.md`.
+Edit its body to note that headroom has been replaced by `crumb`, which ships **no
+telemetry beacon at all** (nothing to disable), while keeping the general "audit new
+tools for phone-home behaviour" guidance. Update the `MEMORY.md` pointer line to match.
+
+- [ ] **Step 6 (optional, local): Prune the stale settings.local.json permission**
+
+In the **default** workspace, `.claude/settings.local.json` may still contain a
+`Read(//home/nixos/wkspace/worktree/feat/headroom-mcp/**)` allow rule from an old
+headroom workspace. This file is local/gitignored (not in this workspace), so it is
+not part of the PR. If desired, remove that one stale permission entry by hand.
+
+- [ ] **Step 7: Create the PR**
+
+Use the `jj-github` agent (or `/jj-pr`) to push the workspace and open a PR.
+Suggested title: `:sparkles: feat(crumb): replace headroom with in-repo zero-dep context store-and-stub`.
+PR body should summarise: what crumb is, that it removes the external overlay + ML
+stack + telemetry, the new store layout, and the verification performed.
+
+---
+
+## Self-Review
+
+**Spec coverage** (each spec section → task):
+- Concept / store-and-stub → Tasks 2–5. ✅
+- Non-goals (no ML/proxy/learn/telemetry) → nothing implements them; telemetry env removed in Tasks 10–12. ✅
+- Naming (`crumb`, tools `compress`/`retrieve`/`stats`, store dir) → Task 1/6 (tool names), Task 2 (`DefaultDir`). ✅
+- Architecture / file structure → Tasks 1–8 create exactly the listed files (+ `ops.go`, called out in File Structure). ✅
+- On-disk layout (blobs + events.jsonl) → Tasks 2–3. ✅
+- compress min-token passthrough → Task 5 (`CompressContent`) + test. ✅
+- retrieve + query filter → Tasks 4–5. ✅
+- stats (+ optional cost) → Tasks 3, 5. ✅
+- Concurrency (content-address + atomic rename + O_APPEND) → Task 2 (`Put`), Task 3 (`AppendEvent`). ✅
+- Stub format → Task 4 (`RenderStub`) + test. ✅
+- Type detection json/jsonl/text → Task 4 + tests. ✅
+- Error handling (-32700/-32601/-32602, ErrNotFound) → Task 6 + Task 2; tests cover -32601/-32700. ✅
+- MCP protocol (initialize/initialized/ping/tools.list/tools.call) → Task 6 + tests. ✅
+- CLI surface → Task 7. ✅
+- Nix integration (flake/home/pi/claude) → Tasks 9–12. ✅
+- settings.local.json + memory → Task 14 steps 5–6. ✅
+- Testing & verification → Tasks 2–8 (unit), Task 14 (system). ✅
+- Defaults table (CRUMB_DIR/MIN_TOKENS/HASH_LEN/GC_DAYS/GC_MAX_MB/PRICE) → Tasks 2,5,7 honor each env var. ✅
+
+**Placeholder scan:** No "TBD"/"add error handling"/"similar to". Every code step shows complete code; every command shows expected output.
+
+**Type consistency:** `Store` methods (`Hash/Put/Get/AppendEvent/ReadStats/GC`), `Event` fields (`TS/Op/Hash/OrigTok/StubTok`), `Summary{Type,Detail,Preview}`, and the shared `dispatchTool(name, json.RawMessage, *Store)` signature are used identically across Tasks 2–7. Tool names `compress`/`retrieve`/`stats` match between `toolDefs` (Task 6) and `dispatchTool` (Task 5). The `version` var is defined once in `main.go` (Task 7) and read in `mcp.go` serverInfo (Task 6) — same package.
+
+**Note on hash length:** the spec's example stub used an 8-char hash for illustration; the implementation uses 12 (configurable via `CRUMB_HASH_LEN`) for collision safety. Functionally identical; tests assert length 12.

--- a/docs/superpowers/specs/2026-06-03-crumb-design.md
+++ b/docs/superpowers/specs/2026-06-03-crumb-design.md
@@ -1,0 +1,227 @@
+# crumb — a zero-dependency context store-and-stub
+
+**Status:** approved design (2026-06-03)
+**Replaces:** the `headroom` MCP integration (`LITl-l/headroom-overlay`)
+
+## Problem
+
+The dotfiles currently depend on `headroom-ai` for context compression in Pi and
+Claude Code. headroom is a large Python+Rust system shipping a HuggingFace model
+(`Kompress-base`), AST compressors, an HTTP proxy, cross-agent memory, and an
+on-by-default telemetry beacon that had to be disabled (`HEADROOM_TELEMETRY=off`).
+It reaches the Nix world only through an external overlay (`LITl-l/headroom-overlay`)
+that we fork and maintain.
+
+In practice we use exactly three MCP tools — `compress`, `retrieve`, `stats` — and
+in an MCP workflow the agent can always call `retrieve`. So the real token win is
+not lossy ML compression; it is **reference indirection**: replace a big blob in the
+transcript with a short stub plus a key, store the original locally, and fetch it on
+demand. That subset is trivially simple and needs no ML, no network, and no
+third-party libraries.
+
+## Goals
+
+- Minimal dependencies: a single static binary, no interpreter, no runtime libraries.
+- Easy for a Nix user: built in-repo with `buildGoModule`, no external flake input,
+  no Cachix.
+- Auditable: a handful of small Go files you can read end-to-end — visibly no
+  telemetry.
+- Drop-in for our usage: same three tool semantics, plus a CLI for PATH parity.
+
+## Non-goals (explicitly dropped — unused in our config)
+
+- ML / AST compressors (the lossy, irreversible path).
+- HTTP proxy server.
+- Cross-agent memory dedup and the `learn` / session-mining command.
+- Any telemetry. There is no beacon and no opt-out knob, because there is nothing
+  to opt out of.
+
+## Naming
+
+The tool is `crumb`: leave a crumb in the transcript, follow it home to the full
+content. The stub marker *is* the breadcrumb.
+
+- CLI binary: `crumb`
+- MCP server id: `crumb`; tool names `compress`, `retrieve`, `stats` (exposed to
+  agents as `mcp__crumb__compress` / `mcp__crumb__retrieve` / `mcp__crumb__stats` —
+  no `crumb_` prefix on the tool name, to avoid the `mcp__crumb__crumb_…` stutter)
+- Nix attribute: `pkgs.crumb`
+- Store directory: `~/.local/state/crumb/` (override with `$CRUMB_DIR`)
+
+## Architecture
+
+A static Go binary, pure standard library (`encoding/json`, `crypto/sha256`, `os`,
+`bufio`, `time`). No external modules, so `go.mod` has no `require` block and
+`buildGoModule` uses `vendorHash = null`.
+
+```
+pkgs/crumb/
+  default.nix     buildGoModule, vendorHash = null, static binary
+  go.mod          module crumb; no require block
+  main.go         arg dispatch: mcp | compress | retrieve | stats | gc
+  mcp.go          JSON-RPC 2.0 stdio loop: initialize, tools/list, tools/call
+  summary.go      type detection + stub rendering + token estimate
+  store.go        content-addressed blob store + JSONL event log + gc
+  *_test.go       unit + protocol tests
+```
+
+Each unit has one purpose, a small interface, and is testable in isolation:
+
+| Unit | Responsibility | Depends on |
+|------|----------------|-----------|
+| `store` | `Put(content) -> hash` (atomic temp+rename, dedup by hash); `Get(hash, query)`; `AppendEvent`; `ReadStats`; `GC` | `os`, `crypto/sha256` |
+| `summary` | detect type {json, jsonl, text}; render stub; estimate tokens (`len/4`) | `encoding/json` |
+| `mcp` | newline-delimited JSON-RPC over stdin/stdout; dispatch the 3 tools | `store`, `summary`, `encoding/json` |
+| `main` | CLI subcommands sharing the same `store` + `summary` | all of the above |
+
+## On-disk layout & data flow
+
+```
+~/.local/state/crumb/            (override: $CRUMB_DIR)
+  blobs/<sha256hex>              one file per unique content (atomic write, dedup-by-name)
+  events.jsonl                   append-only: {ts,op,hash,orig_tok,stub_tok}
+```
+
+- **compress(content):** `h = sha256(content)`. If the estimated size is below
+  `$CRUMB_MIN_TOKENS` (default 50) return the content unchanged — stubbing tiny
+  content is pointless. Otherwise write `blobs/h` (skip if it already exists =
+  dedup), append a `compress` event, and return the stub.
+- **retrieve(hash, query?):** read `blobs/<hash>`. No query → return the full
+  content. With a query → JSON arrays are filtered to elements whose serialization
+  contains the query; text / jsonl are grepped to matching lines plus a match count.
+  A missing or GC'd hash returns a clear "not found (may have been gc'd)" error.
+- **stats():** fold `events.jsonl` into totals — compressions, unique blobs,
+  original vs stub tokens, **tokens saved**, store size on disk, and the most recent
+  events. Cost is shown only if `$CRUMB_PRICE_PER_MTOK` is set; otherwise omitted to
+  stay honest.
+
+### Concurrency
+
+Pi and Claude Code each spawn their own `crumb mcp` process against the same store.
+Content-addressed filenames plus atomic `write-temp + rename` make blob writes
+conflict-free (identical content → identical filename; different content → different
+filename). The event log uses `O_APPEND`, whose small writes are atomic on POSIX. No
+locks and no database are required.
+
+## The stub
+
+What lands in the transcript:
+
+```
+⟦crumb 9f3a1c8e ~14.2k tok type=json keys=[results(312), meta, page]⟧
+preview: {"results":[{"id":1,"name":"alpha","status":"ok"}, …
+↳ retrieve("9f3a1c8e") for full content
+```
+
+Type detection is pure heuristic:
+
+- Parse as JSON. Object → list top-level keys with array lengths
+  (`keys=[results(312), meta, page]`). Array → length plus the first element's keys.
+- Else if every non-empty line parses as JSON → `jsonl` with a line count.
+- Else `text` with line and character counts plus a head preview.
+
+Code and logs fall under `text` (line counts + head preview) rather than pretending
+to parse them. Token estimate is `len(content)/4`, labelled `~` to signal an
+estimate.
+
+## Error handling
+
+Failures surface; they are never silently swallowed.
+
+- Unknown hash → JSON-RPC error `-32602` (invalid params) / CLI exit 1 with a
+  message.
+- Malformed JSON-RPC frame → `-32700` (parse error).
+- Unknown method or tool → `-32601` (method not found).
+- `compress` never fails on unparseable content — it classifies it as `text`.
+- A GC'd retrieval returns an explicit "expired" message so the agent can tell an
+  evicted hash apart from a wrong one.
+
+## MCP protocol
+
+A minimal JSON-RPC 2.0 server over stdio (newline-delimited JSON). Methods handled:
+
+- `initialize` → reply with `serverInfo`, a `tools` capability, and the negotiated
+  `protocolVersion` (echo the client's requested version when supported).
+- `notifications/initialized` → no-op.
+- `ping` → empty result.
+- `tools/list` → the three tools with JSON-Schema `inputSchema`.
+- `tools/call` → dispatch to `compress` / `retrieve` / `stats`, returning a
+  `content` array with a single `text` item.
+
+The exact `protocolVersion` strings accepted are verified during implementation
+against what Claude Code and Pi actually send.
+
+## CLI surface
+
+```
+crumb mcp                         run the stdio MCP server (used by Pi + Claude Code)
+crumb compress [FILE|-]           read FILE or stdin, store it, print the stub
+crumb retrieve <hash> [--query Q] print the original (optionally filtered)
+crumb stats [--json]              print savings + recent events
+crumb gc [--days N] [--max-mb M] [--all]   prune old/oversized blobs; compact log
+crumb --version | --help
+```
+
+## Nix integration (the cleanup)
+
+- **flake.nix:** remove the `headroom` input (`github:LITl-l/headroom-overlay`) and
+  its overlay/linux-gating. Add a local overlay
+  `crumb = final.callPackage ./pkgs/crumb {}` so `pkgs.crumb` resolves in-repo with
+  no external flake and no Cachix.
+- **home.nix:** `pkgs.headroom` → `pkgs.crumb`; delete the `HEADROOM_TELEMETRY` env
+  entry and the headroom-overlay / Cachix comments.
+- **modules/pi.nix:** MCP server `headroom` → `crumb`, command `crumb` with args
+  `["mcp"]`, drop the telemetry env.
+- **modules/claude-code.nix:** rewrite the activation script to
+  `claude mcp remove headroom` (if present) and register `crumb`
+  (`claude mcp add crumb -s user -- crumb mcp`); the idempotency check keys on
+  whether `crumb` is already registered.
+- **.claude/settings.local.json:** drop the stale
+  `Read(.../headroom-mcp/**)` permission.
+- **memory:** update `feedback_audit_tool_telemetry.md` to note crumb has no beacon
+  (the audit instinct still applies to future tools).
+
+## Testing & verification
+
+Go unit and protocol tests, run automatically by `buildGoModule`'s check phase:
+
+- `retrieve` returns a byte-identical original after `compress`.
+- Dedup: compressing identical content twice yields one blob and the same hash.
+- Type detection for JSON object, JSON array, jsonl, and text.
+- Token estimate sanity.
+- Query filtering: JSON array element filter and text line grep.
+- GC: age and size-cap eviction; `retrieve` after GC returns the "expired" error.
+- Concurrency: parallel goroutine writes of identical and distinct content do not
+  corrupt the store or the event log.
+- MCP protocol: a table test feeds `initialize` / `tools/list` / `tools/call` frames
+  and asserts the JSON-RPC responses.
+
+System verification:
+
+1. `nix flake check`
+2. `home-manager switch --flake .`
+3. `claude mcp get crumb` shows the registered server.
+4. Shell roundtrip: `crumb compress < big.json` then `crumb retrieve <hash>` returns
+   the original; `crumb stats` reports the savings.
+
+## Net result vs. today
+
+| | headroom (now) | crumb (proposed) |
+|---|---|---|
+| Runtime deps | Python + Rust + HF model, ML stack | one static binary |
+| Source of truth | external `LITl-l/headroom-overlay` we fork/maintain | in this dotfiles repo |
+| Telemetry | on-by-default beacon (disabled via env) | none exists |
+| Auditability | large multi-language codebase | ~4 small Go files |
+| Compression | lossy ML (irreversible) | reversible store-and-stub |
+
+## Defaults summary
+
+| Knob | Env var | Default |
+|------|---------|---------|
+| Store directory | `$CRUMB_DIR` | `~/.local/state/crumb` |
+| Min size to stub | `$CRUMB_MIN_TOKENS` | 50 tokens |
+| GC age | `$CRUMB_GC_DAYS` | 14 days |
+| GC size cap | `$CRUMB_GC_MAX_MB` | 512 MB |
+| Cost reporting | `$CRUMB_PRICE_PER_MTOK` | unset (omitted) |
+
+GC is manual (`crumb gc`); there is no automatic background eviction.

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,8 @@
         overlays = [
           inputs.claude-code.overlays.default
           inputs.pi.overlays.default
+          # crumb: in-repo context store-and-stub (pure-Go, builds on all platforms).
+          (final: _prev: { crumb = final.callPackage ./pkgs/crumb { }; })
         ];
       });
     in
@@ -258,6 +260,9 @@
             node --test pi/subagents/core.test.ts
             touch "$out"
           '';
+
+          # Build crumb (buildGoModule checkPhase runs `go test ./...`).
+          crumb-tests = pkgs.crumb;
         } // linuxChecks);
 
       # Development shell for testing

--- a/home.nix
+++ b/home.nix
@@ -68,6 +68,10 @@ in
     nixpkgs-fmt # Nix formatter
     nil # Nix LSP
     nix-manager # Custom nix-manager command
+
+    # crumb: in-repo, zero-dependency context store-and-stub (MCP server + CLI).
+    # Pure-Go static binary built from ./pkgs/crumb.
+    crumb
   ];
 
   # Environment variables

--- a/modules/claude-code.nix
+++ b/modules/claude-code.nix
@@ -19,4 +19,21 @@ in
       "${dotfilesClaudePath}/setup-marketplace.sh" --update 2>/dev/null || true
     fi
   '';
+
+  # Register crumb's stdio MCP server with Claude Code at user scope. MCP servers
+  # live in the stateful ~/.claude.json, so we delegate the file location/format to
+  # the `claude` CLI rather than managing it declaratively.
+  #
+  # `claude` is invoked by absolute store path because the new generation's bin/ is
+  # not on PATH during activation; `crumb` is registered as a *bare* command
+  # (resolved from PATH when Claude launches it), which keeps the entry stable
+  # across crumb updates. crumb has no telemetry, so no env is baked in.
+  #
+  # The guard adds `crumb` only when it is not already registered, so activation
+  # stays idempotent.
+  home.activation.registerCrumbMcp = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    if ! ${pkgs.claude-code}/bin/claude mcp get crumb >/dev/null 2>&1; then
+      ${pkgs.claude-code}/bin/claude mcp add crumb -s user -- crumb mcp >/dev/null 2>&1 || true
+    fi
+  '';
 }

--- a/modules/pi.nix
+++ b/modules/pi.nix
@@ -30,6 +30,22 @@
 
   home.file.".pi/agent/themes/claude-code.json".source = ../pi/claude-code-theme.json;
 
+  # Register crumb's context store-and-stub MCP server (stdio transport). Pi reads
+  # ~/.pi/agent/mcp.json. lifecycle "lazy" means Pi only spawns the server when a
+  # crumb tool is actually invoked. crumb is on PATH via home.packages and has no
+  # telemetry, so no opt-out env is needed.
+  home.file.".pi/agent/mcp.json".text = ''
+    {
+      "mcpServers": {
+        "crumb": {
+          "command": "crumb",
+          "args": ["mcp"],
+          "lifecycle": "lazy"
+        }
+      }
+    }
+  '';
+
   # Keep existing pi settings/auth intact, but select the Claude Code-like theme.
   home.activation.setPiClaudeCodeTheme = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     settings="$HOME/.pi/agent/settings.json"

--- a/pkgs/crumb/default.nix
+++ b/pkgs/crumb/default.nix
@@ -1,0 +1,29 @@
+{ buildGoModule, lib }:
+
+buildGoModule {
+  pname = "crumb";
+  version = "0.1.0";
+
+  src = ./.;
+
+  # No third-party modules — the whole tool is Go standard library.
+  vendorHash = null;
+
+  # Run `go test ./...` in the check phase so `nix build`/`nix flake check`
+  # exercise the unit + protocol tests.
+  doCheck = true;
+
+  ldflags = [ "-s" "-w" "-X main.version=0.1.0" ];
+
+  meta = {
+    description = "Zero-dependency context store-and-stub: MCP server + CLI";
+    longDescription = ''
+      crumb stores large content out of an agent's context window (content-addressed,
+      locally) and returns a short stub the agent can follow back with the retrieve
+      tool. Pure Go standard library; no ML, no network, no telemetry.
+    '';
+    mainProgram = "crumb";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/crumb/go.mod
+++ b/pkgs/crumb/go.mod
@@ -1,0 +1,3 @@
+module crumb
+
+go 1.23

--- a/pkgs/crumb/main.go
+++ b/pkgs/crumb/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// version is overridden at build time via -ldflags "-X main.version=…".
+var version = "dev"
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+	switch os.Args[1] {
+	case "--version", "-v", "version":
+		fmt.Println("crumb", version)
+	case "--help", "-h", "help":
+		usage()
+	default:
+		fmt.Fprintln(os.Stderr, "unknown command:", os.Args[1])
+		usage()
+		os.Exit(2)
+	}
+}
+
+func usage() {
+	fmt.Fprint(os.Stderr, `crumb — context store-and-stub
+
+usage:
+  crumb mcp                          run the stdio MCP server
+  crumb compress [FILE|-]            store content, print the crumb stub
+  crumb retrieve <hash> [--query Q]  print stored content (optionally filtered)
+  crumb stats [--json]               print savings + recent events
+  crumb gc [--days N] [--max-mb M] [--all]   prune old/oversized blobs
+  crumb --version | --help
+`)
+}

--- a/pkgs/crumb/main.go
+++ b/pkgs/crumb/main.go
@@ -2,7 +2,11 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"strconv"
+	"strings"
+	"time"
 )
 
 // version is overridden at build time via -ldflags "-X main.version=…".
@@ -14,6 +18,16 @@ func main() {
 		os.Exit(2)
 	}
 	switch os.Args[1] {
+	case "mcp", "serve":
+		runMCP()
+	case "compress":
+		runCompress(os.Args[2:])
+	case "retrieve":
+		runRetrieve(os.Args[2:])
+	case "stats":
+		runStats(os.Args[2:])
+	case "gc":
+		runGC(os.Args[2:])
 	case "--version", "-v", "version":
 		fmt.Println("crumb", version)
 	case "--help", "-h", "help":
@@ -25,6 +39,116 @@ func main() {
 	}
 }
 
+func openStore() *Store {
+	s, err := NewStore(DefaultDir())
+	check(err)
+	return s
+}
+
+func runMCP() {
+	if err := ServeMCP(os.Stdin, os.Stdout, openStore()); err != nil {
+		fmt.Fprintln(os.Stderr, "crumb mcp:", err)
+		os.Exit(1)
+	}
+}
+
+func runCompress(args []string) {
+	var data []byte
+	var err error
+	if len(args) == 0 || args[0] == "-" {
+		data, err = io.ReadAll(os.Stdin)
+	} else {
+		data, err = os.ReadFile(args[0])
+	}
+	check(err)
+	out, err := CompressContent(openStore(), data, time.Now().Unix())
+	check(err)
+	fmt.Println(out)
+}
+
+func runRetrieve(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: crumb retrieve <hash> [--query Q]")
+		os.Exit(2)
+	}
+	hash := args[0]
+	query := ""
+	for i := 1; i < len(args); i++ {
+		if args[i] == "--query" && i+1 < len(args) {
+			query = args[i+1]
+			i++
+		}
+	}
+	out, err := RetrieveContent(openStore(), hash, query)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Print(out)
+	if !strings.HasSuffix(out, "\n") {
+		fmt.Println()
+	}
+}
+
+func runStats(args []string) {
+	out, err := StatsText(openStore())
+	check(err)
+	fmt.Print(out)
+}
+
+func runGC(args []string) {
+	days := envInt("CRUMB_GC_DAYS", 14)
+	maxMB := envInt("CRUMB_GC_MAX_MB", 512)
+	all := false
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--days":
+			if i+1 < len(args) {
+				days = atoiOr(args[i+1], days)
+				i++
+			}
+		case "--max-mb":
+			if i+1 < len(args) {
+				maxMB = atoiOr(args[i+1], maxMB)
+				i++
+			}
+		case "--all":
+			all = true
+		}
+	}
+	store := openStore()
+	var res GCResult
+	var err error
+	if all {
+		res, err = store.GC(time.Now(), time.Nanosecond, 0) // evict everything
+	} else {
+		res, err = store.GC(time.Now(), time.Duration(days)*24*time.Hour, int64(maxMB)*1024*1024)
+	}
+	check(err)
+	fmt.Printf("crumb gc: removed %d blob(s), freed %.2f MB\n", res.Removed, float64(res.FreedBytes)/(1024*1024))
+}
+
+func envInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		return atoiOr(v, def)
+	}
+	return def
+}
+
+func atoiOr(s string, def int) int {
+	if n, err := strconv.Atoi(s); err == nil {
+		return n
+	}
+	return def
+}
+
+func check(err error) {
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "crumb:", err)
+		os.Exit(1)
+	}
+}
+
 func usage() {
 	fmt.Fprint(os.Stderr, `crumb — context store-and-stub
 
@@ -32,8 +156,16 @@ usage:
   crumb mcp                          run the stdio MCP server
   crumb compress [FILE|-]            store content, print the crumb stub
   crumb retrieve <hash> [--query Q]  print stored content (optionally filtered)
-  crumb stats [--json]               print savings + recent events
+  crumb stats                        print savings + recent events
   crumb gc [--days N] [--max-mb M] [--all]   prune old/oversized blobs
   crumb --version | --help
+
+env:
+  CRUMB_DIR             store directory (default ~/.local/state/crumb)
+  CRUMB_MIN_TOKENS      don't stub content below this (default 50)
+  CRUMB_HASH_LEN        short-hash length (default 12)
+  CRUMB_GC_DAYS         gc age in days (default 14)
+  CRUMB_GC_MAX_MB       gc size cap in MB (default 512)
+  CRUMB_PRICE_PER_MTOK  if set, stats shows estimated cost saved
 `)
 }

--- a/pkgs/crumb/mcp.go
+++ b/pkgs/crumb/mcp.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+)
+
+// serverProtocolVersion is used when the client does not request one.
+const serverProtocolVersion = "2025-06-18"
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  interface{}     `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// ServeMCP runs the newline-delimited JSON-RPC stdio loop until in is exhausted.
+// Only JSON responses are written to out; nothing else may touch it.
+func ServeMCP(in io.Reader, out io.Writer, store *Store) error {
+	sc := bufio.NewScanner(in)
+	sc.Buffer(make([]byte, 1024*1024), 64*1024*1024)
+	enc := json.NewEncoder(out)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var req rpcRequest
+		if json.Unmarshal(line, &req) != nil {
+			if err := enc.Encode(rpcResponse{JSONRPC: "2.0", Error: &rpcError{Code: -32700, Message: "parse error"}}); err != nil {
+				return err
+			}
+			continue
+		}
+		resp, isNotification := handleRPC(&req, store)
+		if isNotification {
+			continue
+		}
+		if err := enc.Encode(resp); err != nil {
+			return err
+		}
+	}
+	return sc.Err()
+}
+
+func handleRPC(req *rpcRequest, store *Store) (rpcResponse, bool) {
+	switch req.Method {
+	case "initialize":
+		pv := serverProtocolVersion
+		var p struct {
+			ProtocolVersion string `json:"protocolVersion"`
+		}
+		if json.Unmarshal(req.Params, &p) == nil && p.ProtocolVersion != "" {
+			pv = p.ProtocolVersion
+		}
+		return rpcResponse{
+			JSONRPC: "2.0", ID: req.ID,
+			Result: map[string]interface{}{
+				"protocolVersion": pv,
+				"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+				"serverInfo":      map[string]interface{}{"name": "crumb", "version": version},
+			},
+		}, false
+	case "notifications/initialized":
+		return rpcResponse{}, true
+	case "ping":
+		return rpcResponse{JSONRPC: "2.0", ID: req.ID, Result: map[string]interface{}{}}, false
+	case "tools/list":
+		return rpcResponse{JSONRPC: "2.0", ID: req.ID, Result: map[string]interface{}{"tools": toolDefs()}}, false
+	case "tools/call":
+		return handleToolCall(req, store), false
+	default:
+		if req.ID == nil { // any other notification
+			return rpcResponse{}, true
+		}
+		return rpcResponse{JSONRPC: "2.0", ID: req.ID, Error: &rpcError{Code: -32601, Message: "method not found: " + req.Method}}, false
+	}
+}
+
+func handleToolCall(req *rpcRequest, store *Store) rpcResponse {
+	var p struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	}
+	if json.Unmarshal(req.Params, &p) != nil {
+		return rpcResponse{JSONRPC: "2.0", ID: req.ID, Error: &rpcError{Code: -32602, Message: "invalid params"}}
+	}
+	text, err := dispatchTool(p.Name, p.Arguments, store)
+	if err != nil {
+		return rpcResponse{JSONRPC: "2.0", ID: req.ID, Error: &rpcError{Code: -32602, Message: err.Error()}}
+	}
+	return rpcResponse{JSONRPC: "2.0", ID: req.ID, Result: map[string]interface{}{
+		"content": []map[string]interface{}{{"type": "text", "text": text}},
+	}}
+}
+
+func toolDefs() []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"name":        "compress",
+			"description": "Store large content out of context and return a short crumb stub (hash + summary). Use on big tool outputs, file contents, logs, or search results; retrieve the original later with the retrieve tool.",
+			"inputSchema": map[string]interface{}{
+				"type":     "object",
+				"required": []string{"content"},
+				"properties": map[string]interface{}{
+					"content": map[string]interface{}{"type": "string", "description": "The content to stash."},
+				},
+			},
+		},
+		{
+			"name":        "retrieve",
+			"description": "Retrieve previously stored content by its crumb hash. An optional query filters JSON array elements or text lines.",
+			"inputSchema": map[string]interface{}{
+				"type":     "object",
+				"required": []string{"hash"},
+				"properties": map[string]interface{}{
+					"hash":  map[string]interface{}{"type": "string", "description": "The crumb hash from a compress result."},
+					"query": map[string]interface{}{"type": "string", "description": "Optional filter string."},
+				},
+			},
+		},
+		{
+			"name":        "stats",
+			"description": "Show crumb savings for this store: compressions, tokens saved, store size, and recent events.",
+			"inputSchema": map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
+			},
+		},
+	}
+}

--- a/pkgs/crumb/mcp_test.go
+++ b/pkgs/crumb/mcp_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// runRPC feeds newline-delimited request lines through ServeMCP and returns the
+// decoded response objects (notifications produce no line).
+func runRPC(t *testing.T, store *Store, requests ...string) []map[string]interface{} {
+	t.Helper()
+	in := strings.NewReader(strings.Join(requests, "\n") + "\n")
+	var out bytes.Buffer
+	if err := ServeMCP(in, &out, store); err != nil {
+		t.Fatalf("ServeMCP: %v", err)
+	}
+	var resps []map[string]interface{}
+	for _, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatalf("bad response line %q: %v", line, err)
+		}
+		resps = append(resps, m)
+	}
+	return resps
+}
+
+func TestMCPInitialize(t *testing.T) {
+	s := newTestStore(t)
+	r := runRPC(t, s, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18"}}`)
+	if len(r) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(r))
+	}
+	res := r[0]["result"].(map[string]interface{})
+	if res["protocolVersion"] != "2025-06-18" {
+		t.Fatalf("protocolVersion not echoed: %v", res["protocolVersion"])
+	}
+	if res["serverInfo"].(map[string]interface{})["name"] != "crumb" {
+		t.Fatalf("serverInfo.name wrong: %v", res["serverInfo"])
+	}
+}
+
+func TestMCPNotificationNoResponse(t *testing.T) {
+	s := newTestStore(t)
+	r := runRPC(t, s, `{"jsonrpc":"2.0","method":"notifications/initialized"}`)
+	if len(r) != 0 {
+		t.Fatalf("notification must produce no response, got %d", len(r))
+	}
+}
+
+func TestMCPToolsList(t *testing.T) {
+	s := newTestStore(t)
+	r := runRPC(t, s, `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`)
+	tools := r[0]["result"].(map[string]interface{})["tools"].([]interface{})
+	if len(tools) != 3 {
+		t.Fatalf("expected 3 tools, got %d", len(tools))
+	}
+	names := map[string]bool{}
+	for _, tl := range tools {
+		names[tl.(map[string]interface{})["name"].(string)] = true
+	}
+	for _, want := range []string{"compress", "retrieve", "stats"} {
+		if !names[want] {
+			t.Fatalf("missing tool %q in %v", want, names)
+		}
+	}
+}
+
+func TestMCPToolsCallCompressThenRetrieve(t *testing.T) {
+	s := newTestStore(t)
+	big := strings.Repeat("Q", 4000)
+	bigJSON, _ := json.Marshal(big)
+	r := runRPC(t, s,
+		`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"compress","arguments":{"content":`+string(bigJSON)+`}}}`)
+	content := r[0]["result"].(map[string]interface{})["content"].([]interface{})
+	stub := content[0].(map[string]interface{})["text"].(string)
+	if !strings.HasPrefix(stub, "⟦crumb ") {
+		t.Fatalf("compress did not return a stub: %q", stub)
+	}
+}
+
+func TestMCPUnknownMethod(t *testing.T) {
+	s := newTestStore(t)
+	r := runRPC(t, s, `{"jsonrpc":"2.0","id":9,"method":"does/not/exist"}`)
+	if r[0]["error"] == nil {
+		t.Fatalf("expected error for unknown method")
+	}
+	code := r[0]["error"].(map[string]interface{})["code"].(float64)
+	if int(code) != -32601 {
+		t.Fatalf("error code = %v, want -32601", code)
+	}
+}
+
+func TestMCPParseError(t *testing.T) {
+	s := newTestStore(t)
+	r := runRPC(t, s, `{not valid json`)
+	if r[0]["error"].(map[string]interface{})["code"].(float64) != -32700 {
+		t.Fatalf("expected parse error -32700")
+	}
+}

--- a/pkgs/crumb/ops.go
+++ b/pkgs/crumb/ops.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func minTokens() int {
+	if v := os.Getenv("CRUMB_MIN_TOKENS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			return n
+		}
+	}
+	return 50
+}
+
+func pricePerMTok() float64 {
+	if v := os.Getenv("CRUMB_PRICE_PER_MTOK"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
+			return f
+		}
+	}
+	return 0
+}
+
+// CompressContent stores content and returns a stub. Content below the min-token
+// threshold is returned unchanged (no store, no event).
+func CompressContent(store *Store, content []byte, ts int64) (string, error) {
+	origTok := EstimateTokens(content)
+	if origTok < minTokens() {
+		return string(content), nil
+	}
+	hash, err := store.Put(content)
+	if err != nil {
+		return "", err
+	}
+	sum := detectSummary(content)
+	stub := RenderStub(hash, origTok, sum)
+	stubTok := EstimateTokens([]byte(stub))
+	_ = store.AppendEvent(Event{TS: ts, Op: "compress", Hash: hash, OrigTok: origTok, StubTok: stubTok})
+	return stub, nil
+}
+
+// RetrieveContent reads stored content for hash, optionally filtered by query.
+func RetrieveContent(store *Store, hash, query string) (string, error) {
+	data, err := store.Get(hash)
+	if err != nil {
+		return "", err
+	}
+	return FilterContent(data, detectSummary(data), query), nil
+}
+
+// StatsText renders human-readable savings for the store.
+func StatsText(store *Store) (string, error) {
+	st, err := store.ReadStats(10)
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "crumb store: %s\n", store.dir)
+	fmt.Fprintf(&b, "compressions: %d\n", st.Compressions)
+	fmt.Fprintf(&b, "unique blobs: %d\n", st.UniqueBlobs)
+	fmt.Fprintf(&b, "tokens: orig=%d stub=%d saved=%d\n", st.OrigTokens, st.StubTokens, st.SavedTokens)
+	fmt.Fprintf(&b, "store size: %.2f MB\n", float64(st.StoreBytes)/(1024*1024))
+	if price := pricePerMTok(); price > 0 {
+		fmt.Fprintf(&b, "est cost saved: $%.4f (at $%.2f/Mtok)\n", float64(st.SavedTokens)/1e6*price, price)
+	}
+	if len(st.Recent) > 0 {
+		b.WriteString("recent:\n")
+		for _, e := range st.Recent {
+			fmt.Fprintf(&b, "  %s %s orig=%d stub=%d\n", e.Op, e.Hash, e.OrigTok, e.StubTok)
+		}
+	}
+	return b.String(), nil
+}
+
+// dispatchTool routes an MCP/CLI tool call to the core operations. Shared by the
+// MCP server and (indirectly) the CLI, so the two can never diverge.
+func dispatchTool(name string, args json.RawMessage, store *Store) (string, error) {
+	switch name {
+	case "compress":
+		var a struct {
+			Content string `json:"content"`
+		}
+		if err := json.Unmarshal(args, &a); err != nil {
+			return "", fmt.Errorf("invalid arguments for compress: %w", err)
+		}
+		return CompressContent(store, []byte(a.Content), time.Now().Unix())
+	case "retrieve":
+		var a struct {
+			Hash  string `json:"hash"`
+			Query string `json:"query"`
+		}
+		if err := json.Unmarshal(args, &a); err != nil {
+			return "", fmt.Errorf("invalid arguments for retrieve: %w", err)
+		}
+		return RetrieveContent(store, a.Hash, a.Query)
+	case "stats":
+		return StatsText(store)
+	default:
+		return "", fmt.Errorf("unknown tool: %s", name)
+	}
+}

--- a/pkgs/crumb/ops_test.go
+++ b/pkgs/crumb/ops_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestCompressStoresAndStubs(t *testing.T) {
+	s := newTestStore(t)
+	big := []byte(strings.Repeat("x", 4000)) // ~1000 tokens, above min
+	stub, err := CompressContent(s, big, 1)
+	if err != nil {
+		t.Fatalf("CompressContent: %v", err)
+	}
+	if !strings.HasPrefix(stub, "⟦crumb ") {
+		t.Fatalf("expected a stub, got %q", stub)
+	}
+	// the stub must carry a retrievable hash
+	start := strings.Index(stub, "⟦crumb ") + len("⟦crumb ")
+	hash := stub[start : start+12]
+	got, err := s.Get(hash)
+	if err != nil || string(got) != string(big) {
+		t.Fatalf("retrieve via stub hash failed: err=%v len=%d", err, len(got))
+	}
+}
+
+func TestCompressSmallPassesThrough(t *testing.T) {
+	s := newTestStore(t)
+	small := []byte("tiny")
+	out, err := CompressContent(s, small, 1)
+	if err != nil {
+		t.Fatalf("CompressContent: %v", err)
+	}
+	if out != "tiny" {
+		t.Fatalf("small content should pass through unchanged, got %q", out)
+	}
+}
+
+func TestRetrieveNotFound(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := RetrieveContent(s, "nope00000000", ""); err != ErrNotFound {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestStatsTextReportsSaved(t *testing.T) {
+	s := newTestStore(t)
+	CompressContent(s, []byte(strings.Repeat("y", 4000)), 1)
+	out, err := StatsText(s)
+	if err != nil {
+		t.Fatalf("StatsText: %v", err)
+	}
+	if !strings.Contains(out, "saved=") || !strings.Contains(out, "compressions: 1") {
+		t.Fatalf("stats text = %q", out)
+	}
+}
+
+func TestDispatchToolCompress(t *testing.T) {
+	s := newTestStore(t)
+	args := json.RawMessage(`{"content":` + jsonString(strings.Repeat("z", 4000)) + `}`)
+	out, err := dispatchTool("compress", args, s)
+	if err != nil || !strings.HasPrefix(out, "⟦crumb ") {
+		t.Fatalf("dispatch compress: out=%q err=%v", out, err)
+	}
+}
+
+func jsonString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}

--- a/pkgs/crumb/store.go
+++ b/pkgs/crumb/store.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+// ErrNotFound is returned when a hash has no stored blob (never stored, or gc'd).
+var ErrNotFound = errors.New("crumb: not found (may have been gc'd)")
+
+// Store is a content-addressed blob store with an append-only event log.
+type Store struct {
+	dir       string
+	blobsDir  string
+	eventsLog string
+	hashLen   int
+}
+
+// DefaultDir resolves the store root: $CRUMB_DIR, else $XDG_STATE_HOME/crumb,
+// else ~/.local/state/crumb.
+func DefaultDir() string {
+	if d := os.Getenv("CRUMB_DIR"); d != "" {
+		return d
+	}
+	if d := os.Getenv("XDG_STATE_HOME"); d != "" {
+		return filepath.Join(d, "crumb")
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".local", "state", "crumb")
+}
+
+func hashLenFromEnv() int {
+	if v := os.Getenv("CRUMB_HASH_LEN"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 6 && n <= 64 {
+			return n
+		}
+	}
+	return 12
+}
+
+// NewStore creates the store directories if needed.
+func NewStore(dir string) (*Store, error) {
+	s := &Store{
+		dir:       dir,
+		blobsDir:  filepath.Join(dir, "blobs"),
+		eventsLog: filepath.Join(dir, "events.jsonl"),
+		hashLen:   hashLenFromEnv(),
+	}
+	if err := os.MkdirAll(s.blobsDir, 0o755); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// Hash returns the canonical short id (truncated sha256 hex) for content.
+func (s *Store) Hash(content []byte) string {
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:])[:s.hashLen]
+}
+
+func (s *Store) blobPath(hash string) string {
+	return filepath.Join(s.blobsDir, hash)
+}
+
+// Put stores content (dedup by hash) using an atomic temp-write + rename, and
+// returns its hash.
+func (s *Store) Put(content []byte) (string, error) {
+	hash := s.Hash(content)
+	path := s.blobPath(hash)
+	if _, err := os.Stat(path); err == nil {
+		return hash, nil // already stored
+	}
+	tmp, err := os.CreateTemp(s.blobsDir, ".tmp-*")
+	if err != nil {
+		return "", err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(content); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return "", err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return "", err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName)
+		return "", err
+	}
+	return hash, nil
+}
+
+// Get returns stored content for hash, or ErrNotFound.
+func (s *Store) Get(hash string) ([]byte, error) {
+	data, err := os.ReadFile(s.blobPath(hash))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return data, nil
+}

--- a/pkgs/crumb/store.go
+++ b/pkgs/crumb/store.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"bufio"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
+	"time"
 )
 
 // ErrNotFound is returned when a hash has no stored blob (never stored, or gc'd).
@@ -105,4 +109,165 @@ func (s *Store) Get(hash string) ([]byte, error) {
 		return nil, err
 	}
 	return data, nil
+}
+
+// Event is one row in events.jsonl.
+type Event struct {
+	TS      int64  `json:"ts"`
+	Op      string `json:"op"`
+	Hash    string `json:"hash"`
+	OrigTok int    `json:"orig_tok"`
+	StubTok int    `json:"stub_tok"`
+}
+
+// AppendEvent appends one event via O_APPEND (atomic for small writes on POSIX).
+func (s *Store) AppendEvent(e Event) error {
+	f, err := os.OpenFile(s.eventsLog, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	line, err := json.Marshal(e)
+	if err != nil {
+		return err
+	}
+	line = append(line, '\n')
+	_, err = f.Write(line)
+	return err
+}
+
+// Stats aggregates the event log plus on-disk usage.
+type Stats struct {
+	Compressions int
+	UniqueBlobs  int
+	OrigTokens   int
+	StubTokens   int
+	SavedTokens  int
+	StoreBytes   int64
+	Recent       []Event
+}
+
+// ReadStats folds events.jsonl into totals, keeping the last recentN events.
+func (s *Store) ReadStats(recentN int) (Stats, error) {
+	var st Stats
+	f, err := os.Open(s.eventsLog)
+	if err != nil {
+		if os.IsNotExist(err) {
+			st.StoreBytes, st.UniqueBlobs = s.diskUsage()
+			return st, nil
+		}
+		return st, err
+	}
+	defer f.Close()
+
+	var events []Event
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 1024*1024), 64*1024*1024)
+	for sc.Scan() {
+		var e Event
+		if json.Unmarshal(sc.Bytes(), &e) != nil {
+			continue // skip a corrupt line rather than fail
+		}
+		events = append(events, e)
+		if e.Op == "compress" {
+			st.Compressions++
+			st.OrigTokens += e.OrigTok
+			st.StubTokens += e.StubTok
+		}
+	}
+	st.SavedTokens = st.OrigTokens - st.StubTokens
+	st.StoreBytes, st.UniqueBlobs = s.diskUsage()
+	if recentN > 0 && len(events) > recentN {
+		st.Recent = events[len(events)-recentN:]
+	} else {
+		st.Recent = events
+	}
+	return st, nil
+}
+
+func (s *Store) diskUsage() (int64, int) {
+	entries, err := os.ReadDir(s.blobsDir)
+	if err != nil {
+		return 0, 0
+	}
+	var total int64
+	n := 0
+	for _, e := range entries {
+		if e.IsDir() || e.Name()[0] == '.' {
+			continue // skip leftover .tmp-* files
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		total += info.Size()
+		n++
+	}
+	return total, n
+}
+
+// GCResult reports what GC removed.
+type GCResult struct {
+	Removed    int
+	FreedBytes int64
+}
+
+// GC removes blobs older than maxAge (when >0), then removes the oldest
+// remaining blobs until total size is under maxBytes (when >0). now is injected
+// so tests are deterministic.
+func (s *Store) GC(now time.Time, maxAge time.Duration, maxBytes int64) (GCResult, error) {
+	var res GCResult
+	entries, err := os.ReadDir(s.blobsDir)
+	if err != nil {
+		return res, err
+	}
+	type blob struct {
+		path string
+		size int64
+		mod  time.Time
+	}
+	var blobs []blob
+	for _, e := range entries {
+		if e.IsDir() || e.Name()[0] == '.' {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		blobs = append(blobs, blob{s.blobPath(e.Name()), info.Size(), info.ModTime()})
+	}
+
+	var remaining []blob
+	for _, b := range blobs {
+		if maxAge > 0 && now.Sub(b.mod) > maxAge {
+			if os.Remove(b.path) == nil {
+				res.Removed++
+				res.FreedBytes += b.size
+			}
+			continue
+		}
+		remaining = append(remaining, b)
+	}
+
+	if maxBytes > 0 {
+		var total int64
+		for _, b := range remaining {
+			total += b.size
+		}
+		if total > maxBytes {
+			sort.Slice(remaining, func(i, j int) bool { return remaining[i].mod.Before(remaining[j].mod) })
+			for _, b := range remaining {
+				if total <= maxBytes {
+					break
+				}
+				if os.Remove(b.path) == nil {
+					res.Removed++
+					res.FreedBytes += b.size
+					total -= b.size
+				}
+			}
+		}
+	}
+	return res, nil
 }

--- a/pkgs/crumb/store_test.go
+++ b/pkgs/crumb/store_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func newTestStore(t *testing.T) *Store {
@@ -60,5 +61,65 @@ func TestGetNotFound(t *testing.T) {
 	s := newTestStore(t)
 	if _, err := s.Get("deadbeef0000"); err != ErrNotFound {
 		t.Fatalf("Get(missing) err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestEventsAndStats(t *testing.T) {
+	s := newTestStore(t)
+	s.Put([]byte("aaaa"))
+	if err := s.AppendEvent(Event{TS: 1, Op: "compress", Hash: "h1", OrigTok: 100, StubTok: 10}); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+	s.AppendEvent(Event{TS: 2, Op: "compress", Hash: "h2", OrigTok: 50, StubTok: 5})
+	st, err := s.ReadStats(10)
+	if err != nil {
+		t.Fatalf("ReadStats: %v", err)
+	}
+	if st.Compressions != 2 {
+		t.Fatalf("Compressions = %d, want 2", st.Compressions)
+	}
+	if st.SavedTokens != (100-10)+(50-5) {
+		t.Fatalf("SavedTokens = %d, want 135", st.SavedTokens)
+	}
+	if len(st.Recent) != 2 {
+		t.Fatalf("Recent = %d, want 2", len(st.Recent))
+	}
+}
+
+func TestGCByAge(t *testing.T) {
+	s := newTestStore(t)
+	h, _ := s.Put([]byte("old content here"))
+	// backdate the blob's mtime by 30 days
+	old := time.Now().Add(-30 * 24 * time.Hour)
+	os.Chtimes(s.blobPath(h), old, old)
+	res, err := s.GC(time.Now(), 14*24*time.Hour, 0)
+	if err != nil {
+		t.Fatalf("GC: %v", err)
+	}
+	if res.Removed != 1 {
+		t.Fatalf("GC removed %d, want 1", res.Removed)
+	}
+	if _, err := s.Get(h); err != ErrNotFound {
+		t.Fatalf("after GC Get err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestGCBySize(t *testing.T) {
+	s := newTestStore(t)
+	// three distinct blobs, ~1000 bytes each
+	for i := 0; i < 3; i++ {
+		buf := make([]byte, 1000)
+		for j := range buf {
+			buf[j] = byte('a' + i)
+		}
+		s.Put(buf)
+	}
+	// cap at 1500 bytes -> at least one blob must be evicted
+	res, err := s.GC(time.Now(), 0, 1500)
+	if err != nil {
+		t.Fatalf("GC: %v", err)
+	}
+	if res.Removed < 1 {
+		t.Fatalf("GC by size removed %d, want >=1", res.Removed)
 	}
 }

--- a/pkgs/crumb/store_test.go
+++ b/pkgs/crumb/store_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("CRUMB_HASH_LEN", "12")
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	return s
+}
+
+func TestPutGetRoundtrip(t *testing.T) {
+	s := newTestStore(t)
+	content := []byte(`{"hello":"world","n":[1,2,3]}`)
+	h, err := s.Put(content)
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if len(h) != 12 {
+		t.Fatalf("hash len = %d, want 12", len(h))
+	}
+	got, err := s.Get(h)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("roundtrip mismatch: got %q want %q", got, content)
+	}
+}
+
+func TestPutDedup(t *testing.T) {
+	s := newTestStore(t)
+	c := []byte("the same content, twice")
+	h1, _ := s.Put(c)
+	h2, _ := s.Put(c)
+	if h1 != h2 {
+		t.Fatalf("dedup: hashes differ %q vs %q", h1, h2)
+	}
+	entries, _ := os.ReadDir(filepath.Join(s.dir, "blobs"))
+	n := 0
+	for _, e := range entries {
+		if e.Name()[0] != '.' {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("dedup: expected 1 blob, found %d", n)
+	}
+}
+
+func TestGetNotFound(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.Get("deadbeef0000"); err != ErrNotFound {
+		t.Fatalf("Get(missing) err = %v, want ErrNotFound", err)
+	}
+}

--- a/pkgs/crumb/summary.go
+++ b/pkgs/crumb/summary.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// EstimateTokens is a rough heuristic: ceil(chars / 4).
+func EstimateTokens(content []byte) int {
+	return (len(content) + 3) / 4
+}
+
+func humanTokens(n int) string {
+	if n >= 1000 {
+		return fmt.Sprintf("%.1fk", float64(n)/1000.0)
+	}
+	return fmt.Sprintf("%d", n)
+}
+
+// Summary describes detected structure of content.
+type Summary struct {
+	Type    string // "json" | "jsonl" | "text"
+	Detail  string
+	Preview string
+}
+
+func detectSummary(content []byte) Summary {
+	trimmed := strings.TrimSpace(string(content))
+
+	var js interface{}
+	if trimmed != "" && json.Unmarshal([]byte(trimmed), &js) == nil {
+		switch v := js.(type) {
+		case map[string]interface{}:
+			return Summary{Type: "json", Detail: "keys=[" + jsonObjectKeys(v) + "]", Preview: preview(trimmed)}
+		case []interface{}:
+			detail := fmt.Sprintf("array(%d)", len(v))
+			if len(v) > 0 {
+				if first, ok := v[0].(map[string]interface{}); ok {
+					detail += " elem_keys=[" + jsonObjectKeys(first) + "]"
+				}
+			}
+			return Summary{Type: "json", Detail: detail, Preview: preview(trimmed)}
+		default:
+			return Summary{Type: "json", Detail: "scalar", Preview: preview(trimmed)}
+		}
+	}
+
+	lines := strings.Split(trimmed, "\n")
+	jsonlOK := len(lines) > 1
+	count := 0
+	for _, ln := range lines {
+		ln = strings.TrimSpace(ln)
+		if ln == "" {
+			continue
+		}
+		var x interface{}
+		if json.Unmarshal([]byte(ln), &x) != nil {
+			jsonlOK = false
+			break
+		}
+		count++
+	}
+	if jsonlOK && count > 1 {
+		return Summary{Type: "jsonl", Detail: fmt.Sprintf("%d records", count), Preview: preview(trimmed)}
+	}
+
+	nLines := strings.Count(string(content), "\n") + 1
+	return Summary{Type: "text", Detail: fmt.Sprintf("%d lines, %d chars", nLines, len(content)), Preview: preview(trimmed)}
+}
+
+// jsonObjectKeys lists keys (sorted for determinism), annotating array-valued
+// keys with their length, e.g. "meta, page, results(3)".
+func jsonObjectKeys(m map[string]interface{}) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		if arr, ok := m[k].([]interface{}); ok {
+			parts = append(parts, fmt.Sprintf("%s(%d)", k, len(arr)))
+		} else {
+			parts = append(parts, k)
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+func preview(s string) string {
+	const max = 160
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len(s) > max {
+		return s[:max] + " …"
+	}
+	return s
+}
+
+// RenderStub builds the transcript stub for stored content.
+func RenderStub(hash string, origTok int, sum Summary) string {
+	return fmt.Sprintf("⟦crumb %s ~%s tok type=%s %s⟧\npreview: %s\n↳ retrieve(%q) for full content",
+		hash, humanTokens(origTok), sum.Type, sum.Detail, sum.Preview, hash)
+}
+
+// FilterContent returns the parts of content matching query. JSON arrays are
+// filtered element-wise; text/jsonl/objects are grepped line-wise. An empty
+// query returns the full content.
+func FilterContent(content []byte, sum Summary, query string) string {
+	if query == "" {
+		return string(content)
+	}
+	if sum.Type == "json" {
+		var arr []json.RawMessage
+		if json.Unmarshal(content, &arr) == nil {
+			var matched []string
+			for _, el := range arr {
+				if strings.Contains(string(el), query) {
+					matched = append(matched, string(el))
+				}
+			}
+			return fmt.Sprintf("[%s]\n(%d of %d elements matched %q)",
+				strings.Join(matched, ", "), len(matched), len(arr), query)
+		}
+		// not an array (object/scalar) — fall through to line grep
+	}
+	var out []string
+	for _, ln := range strings.Split(string(content), "\n") {
+		if strings.Contains(ln, query) {
+			out = append(out, ln)
+		}
+	}
+	return fmt.Sprintf("%s\n(%d lines matched %q)", strings.Join(out, "\n"), len(out), query)
+}

--- a/pkgs/crumb/summary_test.go
+++ b/pkgs/crumb/summary_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEstimateTokens(t *testing.T) {
+	if got := EstimateTokens([]byte("abcdefgh")); got != 2 {
+		t.Fatalf("EstimateTokens(8 chars) = %d, want 2", got)
+	}
+}
+
+func TestDetectJSONObject(t *testing.T) {
+	sum := detectSummary([]byte(`{"results":[1,2,3],"meta":{},"page":1}`))
+	if sum.Type != "json" {
+		t.Fatalf("type = %q, want json", sum.Type)
+	}
+	if !strings.Contains(sum.Detail, "results(3)") {
+		t.Fatalf("detail %q missing results(3)", sum.Detail)
+	}
+}
+
+func TestDetectJSONArray(t *testing.T) {
+	sum := detectSummary([]byte(`[{"id":1},{"id":2}]`))
+	if sum.Type != "json" || !strings.Contains(sum.Detail, "array(2)") {
+		t.Fatalf("array detail = %q", sum.Detail)
+	}
+}
+
+func TestDetectJSONL(t *testing.T) {
+	sum := detectSummary([]byte("{\"a\":1}\n{\"a\":2}\n{\"a\":3}"))
+	if sum.Type != "jsonl" || !strings.Contains(sum.Detail, "3 records") {
+		t.Fatalf("jsonl detail = %q type = %q", sum.Detail, sum.Type)
+	}
+}
+
+func TestDetectText(t *testing.T) {
+	sum := detectSummary([]byte("line one\nline two\nplain prose here"))
+	if sum.Type != "text" || !strings.Contains(sum.Detail, "3 lines") {
+		t.Fatalf("text detail = %q type = %q", sum.Detail, sum.Type)
+	}
+}
+
+func TestRenderStub(t *testing.T) {
+	sum := detectSummary([]byte(`{"a":1}`))
+	stub := RenderStub("9f3a1c8e0000", 14200, sum)
+	if !strings.Contains(stub, "9f3a1c8e0000") || !strings.Contains(stub, "~14.2k tok") || !strings.Contains(stub, "type=json") {
+		t.Fatalf("stub = %q", stub)
+	}
+	if !strings.Contains(stub, `retrieve("9f3a1c8e0000")`) {
+		t.Fatalf("stub missing retrieve hint: %q", stub)
+	}
+}
+
+func TestFilterJSONArray(t *testing.T) {
+	content := []byte(`[{"name":"alpha"},{"name":"beta"},{"name":"alphabet"}]`)
+	sum := detectSummary(content)
+	out := FilterContent(content, sum, "alpha")
+	if !strings.Contains(out, "alpha") || !strings.Contains(out, "alphabet") || strings.Contains(out, "beta") {
+		t.Fatalf("filtered array = %q", out)
+	}
+}
+
+func TestFilterTextLines(t *testing.T) {
+	content := []byte("error: boom\ninfo: ok\nerror: bang")
+	sum := detectSummary(content)
+	out := FilterContent(content, sum, "error")
+	if !strings.Contains(out, "boom") || !strings.Contains(out, "bang") || strings.Contains(out, "info: ok") {
+		t.Fatalf("filtered text = %q", out)
+	}
+}
+
+func TestFilterEmptyQueryReturnsAll(t *testing.T) {
+	content := []byte("anything at all")
+	if got := FilterContent(content, detectSummary(content), ""); got != string(content) {
+		t.Fatalf("empty query = %q, want full content", got)
+	}
+}


### PR DESCRIPTION
## What & why

Adds **`crumb`** — an in-repo, zero-dependency context store-and-stub built from scratch — as the replacement for the headroom-ai MCP integration.

> Context: headroom's MCP integration was already removed upstream in #175 while this work was in progress. This PR was rebased onto that, so the diff here is purely **additive** (it introduces crumb); it does not re-do the headroom removal. The net effect across #175 + this PR is: headroom gone, crumb in its place.

headroom was a large Python+Rust system shipping a HuggingFace model, AST compressors, an HTTP proxy, cross-agent memory, and an **on-by-default telemetry beacon**. It reached Nix only through an external overlay we had to fork and maintain. In practice we only used three MCP tools — `compress`, `retrieve`, `stats` — and in an MCP workflow the agent can always call `retrieve`. So the real token win is **reference indirection**, not ML compression: stash a big blob locally, leave a short *crumb* in the transcript, follow it back on demand. That subset needs no ML, no network, and no third-party libraries.

## What `crumb` is

A single static Go binary (pure standard library, **zero external modules**), built with `buildGoModule` (`vendorHash = null`). It is both an MCP stdio server and a CLI.

- `compress` — store content content-addressed under `~/.local/state/crumb/blobs/<sha256>`, return a heuristic stub: `⟦crumb <hash> ~14.2k tok type=json keys=[…]⟧`
- `retrieve <hash> [--query Q]` — read it back (byte-identical), optionally filtered
- `stats` — fold an append-only `events.jsonl` into tokens-saved totals
- `gc` — prune by age / size cap

Concurrency is lock-free: content-addressed filenames + atomic temp-write/rename make Pi and Claude Code writing the same store conflict-free; the event log uses atomic `O_APPEND`. No SQLite, no daemon, **no telemetry** (nothing to opt out of).

## Changes (all additive on top of headroom-free `main`)

- `pkgs/crumb/` — new Go package (`store.go`, `summary.go`, `ops.go`, `mcp.go`, `main.go` + tests) and `default.nix`
- `flake.nix` — add an in-repo `crumb` overlay (`callPackage ./pkgs/crumb`) and a `crumb-tests` flake check
- `home.nix` — add `crumb` to `home.packages`
- `modules/pi.nix` — register the `crumb` MCP server (`mcp.json`, lazy, no env)
- `modules/claude-code.nix` — `registerCrumbMcp` activation (`claude mcp add crumb -s user -- crumb mcp`)
- `docs/superpowers/` — design spec + implementation plan
- `.gitignore` — ignore the local `go build` artifact

## Verification

- `go vet` + `go test ./...` green (unit + JSON-RPC protocol tests); `nix build .#checks.x86_64-linux.crumb-tests` runs the suite in the buildGoModule check phase
- Full `nixos@wsl` activation package builds clean on the rebased base (main + pi-auto-router + crumb)
- Applied live via `home-manager switch`: `crumb` on PATH, MCP server **✓ Connected**, a 4000-byte round-trip verified by **matching sha256**, `claude mcp list` shows only `crumb`
- All GitHub CI checks green (Linux/WSL/NixOS config builds, Nix formatting, flake validation, module tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
