### PR TITLE
:zap: perf(nvim): fix ~4s file-open stall and add jj-aware inline blame

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -67,6 +67,12 @@ vim.keymap.set('n', '<leader>fm', function() plugins.pick('marks') end, { desc =
 vim.keymap.set('n', '<leader>fo', function() plugins.pick('options') end, { desc = 'Find options' })
 vim.keymap.set('n', '<leader>fC', function() plugins.pick_colorschemes() end, { desc = 'Pick colorscheme' })
 
+-- Git blame: toggle inline per-line blame. Lazy-loads config.blame on first use.
+-- Works in jj workspaces with no `.git` (uses `jj file annotate`) and falls back
+-- to `git blame` elsewhere.
+vim.keymap.set('n', '<leader>gb', function() require('config.blame').toggle() end, { desc = 'Toggle inline blame' })
+vim.api.nvim_create_user_command('BlameToggle', function() require('config.blame').toggle() end, { desc = 'Toggle inline git/jj blame' })
+
 -- Debug keymaps lazy-load DAP on first use, then config.dap replaces these stubs.
 local function with_dap(callback)
   return function()
@@ -122,10 +128,21 @@ vim.api.nvim_create_autocmd({ 'BufReadPre', 'BufNewFile' }, {
   group = lazy_group,
   once = true,
   callback = function()
-    plugins.setup_editing()
-    plugins.setup_git()
-    plugins.setup_lsp()
-    plugins.setup_format()
+    -- Let the buffer paint first, then warm up editing/git/LSP/format on the
+    -- next loop tick. Starting the LSP client pulls in the vim.lsp.* runtime
+    -- (~0.7s on this WSL box) and must not block the file from appearing.
+    local buf = vim.api.nvim_get_current_buf()
+    vim.schedule(function()
+      plugins.setup_editing()
+      plugins.setup_git()
+      plugins.setup_lsp()
+      plugins.setup_format()
+      -- setup_lsp() enables the servers only now — after this buffer's FileType
+      -- already fired — so re-emit FileType to attach them to the open buffer.
+      if vim.api.nvim_buf_is_valid(buf) then
+        vim.api.nvim_exec_autocmds('FileType', { buffer = buf })
+      end
+    end)
   end,
 })
 

--- a/nvim/lua/config/blame.lua
+++ b/nvim/lua/config/blame.lua
@@ -1,0 +1,157 @@
+-- Toggleable inline blame for the current line.
+--
+-- Shows the change that last touched the cursor line as virtual text at the
+-- end of the line, gitsigns-style. The backend is chosen per file: jj when the
+-- file lives in a jj repo/workspace (so blame keeps working where there is no
+-- `.git`, e.g. a secondary `jj workspace`), otherwise plain git.
+--
+-- Blame is computed once per buffer (asynchronously) and re-used on cursor
+-- movement; it refreshes on write, when line numbers can shift.
+
+local M = {}
+
+local ns = vim.api.nvim_create_namespace('inline_blame')
+local augroup = vim.api.nvim_create_augroup('InlineBlame', { clear = true })
+
+-- Per-buffer state, keyed by bufnr:
+--   { enabled = bool, lines = { [lnum] = { rev, author, date, summary } } }
+local state = {}
+
+-- jj template: change-id, author, date, summary for each line, NUL-delimited,
+-- one row per source line so output line N maps to buffer line N.
+local JJ_TEMPLATE = table.concat({
+  'commit.change_id().shortest(8)',
+  'commit.author().name()',
+  'commit.author().timestamp().local().format("%Y-%m-%d")',
+  'commit.description().first_line()',
+}, [[ ++ "\x00" ++ ]]) .. [[ ++ "\n"]]
+
+-- jj is the user's primary VCS and is always installed alongside `.jj`, but
+-- probe once (and cache) so detection never assumes a tool that is absent.
+local has_jj
+local function detect_vcs(file)
+  local dir = vim.fs.dirname(file)
+  if vim.fs.find('.jj', { path = dir, upward = true, type = 'directory' })[1] then
+    if has_jj == nil then has_jj = vim.fn.executable('jj') == 1 end
+    if has_jj then return 'jj' end
+  end
+  if vim.fs.find('.git', { path = dir, upward = true })[1] then
+    return 'git'
+  end
+  return nil
+end
+
+local function parse_jj(stdout)
+  local lines, n = {}, 0
+  for row in vim.gsplit(stdout, '\n', { plain = true }) do
+    if row ~= '' then
+      n = n + 1
+      local f = vim.split(row, '\0', { plain = true })
+      lines[n] = { rev = f[1], author = f[2], date = f[3], summary = f[4] or '' }
+    end
+  end
+  return lines
+end
+
+local function parse_git(stdout)
+  local lines, cur, lnum = {}, nil, nil
+  for row in vim.gsplit(stdout, '\n', { plain = true }) do
+    local hash, final = row:match('^(%x+)%s+%d+%s+(%d+)')
+    if hash and #hash >= 7 then
+      lnum = tonumber(final)
+      cur = { rev = hash:sub(1, 8) }
+    elseif row:sub(1, 1) == '\t' then
+      if cur and lnum then lines[lnum] = cur end
+      cur = nil
+    elseif cur then
+      local k, v = row:match('^(%S+) (.*)$')
+      if k == 'author' then
+        cur.author = v
+      elseif k == 'author-time' then
+        cur.date = os.date('%Y-%m-%d', tonumber(v))
+      elseif k == 'summary' then
+        cur.summary = v
+      end
+    end
+  end
+  return lines
+end
+
+local function render(buf)
+  local st = state[buf]
+  if not st or not st.enabled then return end
+  if vim.api.nvim_get_current_buf() ~= buf then return end
+  vim.api.nvim_buf_clear_namespace(buf, ns, 0, -1)
+  if not st.lines then return end
+  local lnum = vim.api.nvim_win_get_cursor(0)[1]
+  local info = st.lines[lnum]
+  if not info or not info.rev then return end
+  local text = string.format('  %s · %s · %s · %s',
+    info.rev, info.author or '?', info.date or '', info.summary or '')
+  pcall(vim.api.nvim_buf_set_extmark, buf, ns, lnum - 1, 0, {
+    virt_text = { { text, 'Comment' } },
+    virt_text_pos = 'eol',
+    hl_mode = 'combine',
+  })
+end
+
+local function refresh(buf)
+  local st = state[buf]
+  if not st or not st.enabled then return end
+  local file = vim.api.nvim_buf_get_name(buf)
+  if file == '' or vim.fn.filereadable(file) == 0 then return end
+  local vcs = detect_vcs(file)
+  if not vcs then
+    vim.notify('inline blame: not a git or jj repository', vim.log.levels.WARN)
+    return
+  end
+  local cmd = vcs == 'jj'
+    and { 'jj', 'file', 'annotate', '--ignore-working-copy', '-T', JJ_TEMPLATE, file }
+    or { 'git', 'blame', '--line-porcelain', file }
+  vim.system(cmd, { cwd = vim.fs.dirname(file), text = true }, function(res)
+    vim.schedule(function()
+      local s = state[buf]
+      if not s or not s.enabled then return end
+      if res.code ~= 0 then
+        vim.notify('inline blame failed: ' .. (res.stderr or ''):gsub('%s+$', ''), vim.log.levels.WARN)
+        return
+      end
+      s.lines = vcs == 'jj' and parse_jj(res.stdout) or parse_git(res.stdout)
+      render(buf)
+    end)
+  end)
+end
+
+function M.toggle()
+  local buf = vim.api.nvim_get_current_buf()
+  local st = state[buf]
+  if st and st.enabled then
+    st.enabled = false
+    vim.api.nvim_buf_clear_namespace(buf, ns, 0, -1)
+    vim.api.nvim_clear_autocmds({ group = augroup, buffer = buf })
+    vim.notify('inline blame: off')
+    return
+  end
+  state[buf] = { enabled = true }
+  -- Update the displayed line on cursor movement (cache lookup + extmark only).
+  vim.api.nvim_create_autocmd({ 'CursorMoved', 'CursorMovedI' }, {
+    group = augroup,
+    buffer = buf,
+    callback = function() render(buf) end,
+  })
+  -- Line numbers shift on write, so recompute the blame for the saved file.
+  vim.api.nvim_create_autocmd('BufWritePost', {
+    group = augroup,
+    buffer = buf,
+    callback = function() refresh(buf) end,
+  })
+  vim.api.nvim_create_autocmd({ 'BufWipeout', 'BufDelete' }, {
+    group = augroup,
+    buffer = buf,
+    callback = function() state[buf] = nil end,
+  })
+  vim.notify('inline blame: on')
+  refresh(buf)
+end
+
+return M

--- a/nvim/lua/config/lsp.lua
+++ b/nvim/lua/config/lsp.lua
@@ -187,9 +187,40 @@ local server_executables = {
   terraformls = 'terraform-ls',
 }
 
--- Check if executable exists in PATH
+-- Check if executable exists in PATH.
+--
+-- vim.fn.executable() scans every entry in $PATH. Under WSL the inherited
+-- Windows directories (/mnt/c/...) sit on a slow 9p mount, so a single missed
+-- lookup costs ~280ms; probing all ~14 language servers on the first file open
+-- froze Neovim for ~4 seconds before the buffer painted. Every server here is
+-- Nix-provided and never lives under /mnt, so we probe against a PATH with the
+-- /mnt entries stripped out (computed once) and cache each result.
+local fast_path
+local function get_fast_path()
+  if fast_path then return fast_path end
+  local kept = {}
+  for dir in string.gmatch(vim.env.PATH or '', '[^:]+') do
+    if not vim.startswith(dir, '/mnt/') then
+      kept[#kept + 1] = dir
+    end
+  end
+  fast_path = table.concat(kept, ':')
+  return fast_path
+end
+
+local exe_cache = {}
 local function executable_exists(name)
-  return vim.fn.executable(name) == 1
+  local cached = exe_cache[name]
+  if cached ~= nil then return cached end
+  -- Reuse Vim's own resolution over the /mnt-free PATH. The swap is fully
+  -- synchronous (nothing yields between set and restore), so no child process
+  -- or callback ever observes the temporary PATH.
+  local saved = vim.env.PATH
+  vim.env.PATH = get_fast_path()
+  local ok = vim.fn.executable(name) == 1
+  vim.env.PATH = saved
+  exe_cache[name] = ok
+  return ok
 end
 
 -- Setup a single LSP server


### PR DESCRIPTION
## Why

Opening **any** file froze Neovim for ~4–5s before the buffer painted (empty `nvim` started in ~29ms). Separately, `git blame` / `mini.git` don't work in the jj-only workspaces under `~/wkspace/worktree/*` because those have no `.git`.

## Part 1 — file-open stall (~5242ms → ~45ms first paint)

**Root cause:** `config.lsp.setup()` probes ~14 language-server executables with `vim.fn.executable()` on the `BufReadPre` path. Under WSL, `$PATH` carries **47 Windows `/mnt/c/...` entries** on a slow 9p mount, so each missed lookup costs **~280ms** (14 × ≈ 4s), all *before* the buffer paints.

- `nvim/lua/config/lsp.lua`: probe against a `/mnt`-free `$PATH` (computed once, cached per binary). The swap around `vim.fn.executable()` is fully synchronous, so nothing else observes the temporary PATH.
- `nvim/init.lua`: defer the editing/git/LSP/format warm-up to the next tick via `vim.schedule` so the buffer paints first, then re-emit `FileType` for the buffer so the just-enabled LSP servers still attach.

## Part 2 — toggleable jj/git inline blame

`<leader>gb` / `:BlameToggle` show end-of-line virtual text (`change · author · date · summary`) for the cursor line.

- `nvim/lua/config/blame.lua` (new): backend chosen per file — `jj file annotate` when a `.jj` dir is found upward (so it works in jj-only workspaces with **no `.git`**), `git blame --line-porcelain` otherwise. Computed async once per buffer, refreshed on write; toggle off clears marks/autocmds.

## Verification

- First-paint startuptime: **5242ms → ~45ms**; `lua_ls` still attaches on both `nvim file` and `:edit`.
- jj blame exercised live in a jj-only workspace; `parse_git` unit-tested incl. the all-zeros "Not Committed Yet" case.
- `nix flake check` passes (incl. the repo's `nvim-config-tests`); `nixos@wsl` activation package builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
