### PR TITLE
:wrench: chore(claude): enable skill-creator/plugin-dev/sourcegraph plugins, skip workflow warning

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -120,10 +120,14 @@
     "explanatory-output-style@claude-plugins-official": true,
     "playground@claude-plugins-official": true,
     "learning-output-style@claude-plugins-official": true,
-    "context7@claude-plugins-official": false
+    "context7@claude-plugins-official": false,
+    "skill-creator@claude-plugins-official": true,
+    "plugin-dev@claude-plugins-official": true,
+    "sourcegraph@claude-plugins-official": true
   },
   "effortLevel": "xhigh",
   "showThinkingSummaries": true,
+  "skipWorkflowUsageWarning": true,
   "theme": "light",
   "editorMode": "vim",
   "skipAutoPermissionPrompt": true,


### PR DESCRIPTION
## Summary

Updates `claude/settings.json` to enable three additional Claude Code plugins and silence the workflow-usage warning.

## Changes

- Enable `skill-creator@claude-plugins-official`
- Enable `plugin-dev@claude-plugins-official`
- Enable `sourcegraph@claude-plugins-official`
- Add `"skipWorkflowUsageWarning": true`

## Notes

- An unrelated `flake.lock` update present in the working copy was intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)