### PR TITLE
:bug: fix(yazi): use mime=inode/directory for open rule (yazi requires url or mime)

### DIFF
--- a/modules/yazi.nix
+++ b/modules/yazi.nix
@@ -61,7 +61,7 @@
       # Rules for which opener to use based on file type
       open = {
         rules = [
-          { name = "*/"; use = "edit"; }          # Directories
+          { mime = "inode/directory"; use = "edit"; }  # Directories
           { mime = "text/*"; use = "edit"; }      # Text files
           { mime = "image/*"; use = "open"; }     # Images with system viewer
           { mime = "video/*"; use = "play"; }     # Videos in mpv


### PR DESCRIPTION
## Summary

Fixes a yazi startup error caused by an invalid `open.rules` entry in `modules/yazi.nix`.

The directory rule previously used `name = "*/"`, which recent yazi versions reject with:

> at least one of `url` or `mime` must be specified

This rule is changed to `{ mime = "inode/directory"; use = "edit"; }`, which yazi accepts for matching directories.

## Verification

- Applied config with `home-manager switch --flake .#nixos@wsl`
- Confirmed yazi now parses its config with no TOML error

🤖 Generated with [Claude Code](https://claude.com/claude-code)