### PR TITLE
:sparkles: feat(nvim): enable mini.jump2d on-screen label motion

### DIFF
--- a/nvim/lua/config/plugins.lua
+++ b/nvim/lua/config/plugins.lua
@@ -97,6 +97,9 @@ M.setup_editing = function()
     -- Mini.ai (better text objects)
     require('mini.ai').setup()
 
+    -- Mini.jump2d (jump to any visible spot via on-screen labels; <CR> to start)
+    require('mini.jump2d').setup()
+
     -- Mini.splitjoin
     require('mini.splitjoin').setup()
 


### PR DESCRIPTION
## Summary

Enable mini.nvim's `mini.jump2d` module by adding `require('mini.jump2d').setup()` to the editing group in `nvim/lua/config/plugins.lua` (inside `M.setup_editing()`, right after `mini.ai`).

This adds an on-screen-label jump motion bound to `<CR>` in normal/visual/operator-pending modes — type `<CR>` to label every visible spot, then a label to jump there.

## Why no Nix change

`mini.jump2d` ships inside the already-installed `mini-nvim` plugin, so no flake/module change was needed.

## Verification

- `home-manager switch --flake .#nixos@wsl` succeeded
- Headless nvim load test passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)