### PR TITLE
:bug: fix(claude): install missing plugins (architect, sourcegraph) via setup-marketplace.sh

### DIFF
--- a/claude/README.md
+++ b/claude/README.md
@@ -25,13 +25,17 @@ Claude Code supports three plugin sources:
 
 ## Adding Official Plugins
 
-Official plugins from `claude-plugins-official` are **installed automatically** - you just need to enable them in Claude Code.
+Enabling an official plugin in `settings.json` (`enabledPlugins`) only **toggles**
+it — it does not fetch it. The plugin must also be installed via
+`claude plugin install` for the toggle to point at anything. To keep a fresh
+machine reproducible, list every enabled official plugin in the
+`OFFICIAL_PLUGINS` array in `setup-marketplace.sh`, which installs them.
 
 ### Enabling Official Plugins
 
-1. Open Claude Code
-2. Use the `/plugin` command or settings menu
-3. Browse and enable plugins from the official marketplace
+1. Add `"plugin@claude-plugins-official": true` to `enabledPlugins` in `settings.json`
+2. Add `"plugin@claude-plugins-official"` to the `OFFICIAL_PLUGINS` array in `setup-marketplace.sh`
+3. Run `./claude/setup-marketplace.sh --update` (from a separate terminal, not inside Claude Code)
 
 ### Available Official Plugins
 
@@ -191,7 +195,9 @@ No JSON merging, no symlinks, no jq — the CLI handles all state management.
 1. Create your plugin under `marketplaces/local/plugins/your-plugin/`
 2. Add it to `marketplaces/local/.claude-plugin/marketplace.json`
 3. Add `"your-plugin@local"` to the `PLUGINS` array in `setup-marketplace.sh`
-4. Run `./claude/setup-marketplace.sh --update`
+   (use the `OFFICIAL_PLUGINS` array instead for `@claude-plugins-official` plugins)
+4. Enable it in `settings.json`'s `enabledPlugins`
+5. Run `./claude/setup-marketplace.sh --update`
 
 ## Installing Skills
 

--- a/claude/setup-marketplace.sh
+++ b/claude/setup-marketplace.sh
@@ -22,9 +22,21 @@ info() { echo -e "${GREEN}[INFO]${NC} $*"; }
 warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
 error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 
-# Plugins to install (add new plugins here)
+# Plugins to install from the local marketplace (add new plugins here).
+# Keep this in sync with the "@local" entries in claude/settings.json's
+# enabledPlugins.
 PLUGINS=(
   "jj-master@local"
+  "architect@local"
+)
+
+# Plugins to install from the official marketplace. settings.json's
+# enabledPlugins only TOGGLES these on/off -- it does not fetch them, so any
+# official plugin enabled there must also be listed here to actually install.
+# Keep this in sync with the enabled "@claude-plugins-official" entries.
+OFFICIAL_MARKETPLACE="anthropics/claude-plugins-official"
+OFFICIAL_PLUGINS=(
+  "sourcegraph@claude-plugins-official"
 )
 
 # Remote MCP servers registered at user scope (not bundled as plugins).
@@ -84,6 +96,14 @@ install() {
     claude plugin install "$plugin" --scope user
   done
 
+  info "Adding official marketplace: $OFFICIAL_MARKETPLACE"
+  claude plugin marketplace add "$OFFICIAL_MARKETPLACE" 2>/dev/null || true
+
+  for plugin in "${OFFICIAL_PLUGINS[@]}"; do
+    info "Installing plugin: $plugin"
+    claude plugin install "$plugin" --scope user
+  done
+
   setup_mcp
 
   echo ""
@@ -94,7 +114,7 @@ install() {
 uninstall() {
   check_claude
 
-  for plugin in "${PLUGINS[@]}"; do
+  for plugin in "${PLUGINS[@]}" "${OFFICIAL_PLUGINS[@]}"; do
     info "Removing plugin: $plugin"
     claude plugin uninstall "$plugin" --scope user 2>/dev/null || true
   done
@@ -117,6 +137,16 @@ update() {
   claude plugin marketplace update local
 
   for plugin in "${PLUGINS[@]}"; do
+    info "Reinstalling plugin: $plugin"
+    claude plugin uninstall "$plugin" --scope user 2>/dev/null || true
+    claude plugin install "$plugin" --scope user
+  done
+
+  info "Updating official marketplace..."
+  claude plugin marketplace add "$OFFICIAL_MARKETPLACE" 2>/dev/null || true
+  claude plugin marketplace update claude-plugins-official
+
+  for plugin in "${OFFICIAL_PLUGINS[@]}"; do
     info "Reinstalling plugin: $plugin"
     claude plugin uninstall "$plugin" --scope user 2>/dev/null || true
     claude plugin install "$plugin" --scope user


### PR DESCRIPTION
## Problem

Three plugins were enabled in `claude/settings.json` (`enabledPlugins`) but never actually installed, because:

- `install.sh --update` is the **Nix/Home-Manager** updater — it never touches Claude Code plugins. The Claude plugin installer is the separate `claude/setup-marketplace.sh`.
- `enabledPlugins` is only a **toggle**; a plugin must still be `claude plugin install`-ed and its marketplace added.
- `setup-marketplace.sh` only installed `jj-master@local` — it was missing `architect@local`, and had no handling for official-marketplace plugins.

Confirmed missing (enabled but not in `installed_plugins.json`): `jj-master@local`, `architect@local`, `sourcegraph@claude-plugins-official`.

## Fix

- Add `architect@local` to the `PLUGINS` array.
- Add an `OFFICIAL_PLUGINS` array (+ `OFFICIAL_MARKETPLACE`) so enabled official plugins like `sourcegraph` are actually installed; wired into `install`/`update`/`uninstall`.
- Correct `claude/README.md`: official plugins are **not** installed automatically by enabling — document that they must be listed in `OFFICIAL_PLUGINS` and installed via the script.

## Verification

- `bash -n claude/setup-marketplace.sh` passes (script mutates live Claude config, so it can't be executed from inside Claude Code).
- Trailing newlines preserved on both files.

Note: applying this still requires running `./claude/setup-marketplace.sh --update` from a separate terminal (outside Claude Code).