### PR TITLE
:wrench: chore(claude): pin model to opus-4-7[1m]

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -63,6 +63,7 @@
     ],
     "defaultMode": "auto"
   },
+  "model": "claude-opus-4-7[1m]",
   "hooks": {
     "PreToolUse": [
       {


### PR DESCRIPTION
## Summary

Set Claude Code's default model to `opus-4-7[1m]` in `claude/settings.json` so the 1M-context Opus variant is the session default instead of relying on runtime selection / `/model` per-session.

## Test plan

- [ ] After merge, new Claude Code sessions report `claude-opus-4-7[1m]` as the active model without manual selection