### PR TITLE
:arrow_up: chore(flake): bump claude-code, fzf.fish, home-manager, nixpkgs inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,15 +1,43 @@
 {
   "nodes": {
+    "bun2nix": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "pi",
+          "nixpkgs"
+        ],
+        "systems": [
+          "pi",
+          "systems"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1778446047,
+        "narHash": "sha256-oQvcadh2BCkrog+SGrG6YffKJrveYpjj3TdQJWaKhaM=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "f2bc12af1a6369648aac41041ceeaa0b866599c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "2.1.0",
+        "repo": "bun2nix",
+        "type": "github"
+      }
+    },
     "claude-code": {
       "inputs": {
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1780424083,
-        "narHash": "sha256-rLZlfCYiYsHZVaJSB9/gptH2wVrlCRoNh8NBWi4flnU=",
+        "lastModified": 1781829044,
+        "narHash": "sha256-XS5YlvRDDo+WjK+SUyIP4FvG1Mb2wcYBY4b1jRoorUE=",
         "owner": "ryoppippi",
         "repo": "claude-code-overlay",
-        "rev": "0c2e95452c12f9df8e7f1978e8a348c71b22758c",
+        "rev": "10882a469fb71c2acb6d38fb7d4b2592991f6031",
         "type": "github"
       },
       "original": {
@@ -21,11 +49,11 @@
     "fish-plugin-fzf": {
       "flake": false,
       "locked": {
-        "lastModified": 1773169111,
-        "narHash": "sha256-H7HgYT+okuVXo2SinrSs+hxAKCn4Q4su7oMbebKd/7s=",
+        "lastModified": 1781825110,
+        "narHash": "sha256-ql8UncXGwOIpyC49w1bCRfynRB02u7s1a1rOWTfKcTk=",
         "owner": "PatrickF1",
         "repo": "fzf.fish",
-        "rev": "0069dbbe06cc05482bfb13063b4b4eac26318992",
+        "rev": "6a6136998879dcc1f29a405dfdd6b92c5f229c39",
         "type": "github"
       },
       "original": {
@@ -50,6 +78,28 @@
         "type": "github"
       }
     },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "pi",
+          "bun2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777988971,
+        "narHash": "sha256-qIoWPDs+0/8JecyYgE3gpKQxW/4bLW/gp45vow9ioCQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "0678d8986be1661af6bb555f3489f2fdfc31f6ff",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -57,11 +107,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780408569,
-        "narHash": "sha256-s7Tv6FUQThRAvW8En8XVC6HMb0uiikzVccCcCo9u/Bg=",
+        "lastModified": 1781837603,
+        "narHash": "sha256-zGIqa68+DxfGlepR07ZK00GaEz2++YlYRRpyJu5WUP4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f384af1bec6423a0d4ba1855917ab948f64e5808",
+        "rev": "0f4a317c06ed69a4b15441490d46cdccd24c98c7",
         "type": "github"
       },
       "original": {
@@ -88,11 +138,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1780336545,
-        "narHash": "sha256-vhVhuXzFrIOfcssC/9hDHx7MHzDKjF3keHuREOQqQiQ=",
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4df1b885d76a54e1aa1a318f8d16fd6005b6401f",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
         "type": "github"
       },
       "original": {
@@ -120,15 +170,16 @@
     },
     "pi": {
       "inputs": {
+        "bun2nix": "bun2nix",
         "nixpkgs": "nixpkgs_3",
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1780390085,
-        "narHash": "sha256-QxqhqenhltMfpvRBE3qJ+hic3wqGVNM7cCzHNV+thms=",
+        "lastModified": 1781803074,
+        "narHash": "sha256-evA6Q8cGuqIaoYtV0KPwyN/qipU3ulKcf9nr6Fp064Y=",
         "owner": "lukasl-dev",
         "repo": "pi.nix",
-        "rev": "36f07522adfbe92d0ebe02cb0082e3989a2870c7",
+        "rev": "826bd3586bd7b9a3b7189c5e4a2678d892e2d50b",
         "type": "github"
       },
       "original": {
@@ -159,6 +210,28 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "pi",
+          "bun2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     }


### PR DESCRIPTION
## Summary

Routine flake input refresh — `flake.lock` only.

- `claude-code-overlay` (ryoppippi): `0c2e954` → `10882a4`
- `fish-plugin-fzf` (PatrickF1/fzf.fish): `0069dbb` → `6a61369`
- `home-manager`: `f384af1` → `0f4a317`
- `nixpkgs` (unstable): `4df1b88` → `3e41b24`
- `pi` (transitive): `36f0752` → `826bd35`
- Plus transitive `bun2nix` / `flake-parts` adds

## Test plan

- [ ] `nix flake check` passes
- [ ] `home-manager switch --flake .` succeeds
- [ ] `sudo nixos-rebuild switch` succeeds on the host