### PR TITLE
:wrench: chore(claude): allow gh api reads, keep PR/merge writes in ask

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -42,6 +42,7 @@
       "Bash(gh run list:*)",
       "Bash(gh auth:*)",
       "Bash(gh repo view:*)",
+      "Bash(gh api:*)",
       "Bash(direnv:*)",
       "Bash(fish:*)"
     ],
@@ -58,7 +59,6 @@
       "Bash(jj git push:*)",
       "Bash(gh pr create:*)",
       "Bash(gh pr merge:*)",
-      "Bash(gh api:*)",
       "Bash(nix flake update:*)"
     ],
     "defaultMode": "auto"


### PR DESCRIPTION
## Summary

- Moves `Bash(gh api:*)` from `permissions.ask` to `permissions.allow` so read-only `gh api` calls no longer prompt for approval.
- Keeps `Bash(gh pr create:*)`, `Bash(gh pr merge:*)`, `Bash(git push:*)`, and `Bash(jj git push:*)` in `permissions.ask` to gate write operations.

## Why

Read-only `gh api` queries (e.g. checking for existing PRs, listing repos) don't change state and can safely run without prompts. Keeping write operations gated reduces noise while maintaining safety.

## Trade-off

Rules are prefix-matched, so `Bash(gh api:*)` now allows `gh api -X POST/PATCH/DELETE` as well. This is acceptable because actual PR creation still goes through `gh pr create` which remains in `ask`, providing an explicit approval gate for the common write path.