### PR TITLE
:sparkles: feat(home): add btop resource monitor

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -46,6 +46,7 @@ in
     jq # JSON processor
     yq-go # YAML processor
     htop # Process viewer
+    btop # Modern resource monitor (htop successor)
     tree # Directory tree viewer
     curl # HTTP client
     wget # File downloader


### PR DESCRIPTION
## Summary
- Adds `btop` (modern resource monitor, htop successor) to `home.packages` next to the existing `htop`.

## Test plan
- [x] `nix flake check` — passes (only pre-existing unrelated warnings).
- [x] `home-manager switch --flake .#nixos@wsl` — applied cleanly.
- [x] `btop --version` → `1.4.7`, binary resolves at `~/.nix-profile/bin/btop`.