### PR TITLE
:wrench: chore(claude): allow gh api reads, hook-gate writes

### DIFF
--- a/claude/gh-api-write-guard.sh
+++ b/claude/gh-api-write-guard.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# PreToolUse hook (matcher: Bash, if: Bash(gh api:*)): force ask on writes.
+# `Bash(gh api:*)` is in permissions.allow so GET-shape reads pass through,
+# but prefix-matched rules can't distinguish HTTP method (the flag comes
+# after the endpoint). This hook closes the gap where `gh api -X POST
+# repos/.../pulls` would otherwise create a PR without the `gh pr create`
+# ask prompt firing.
+
+set -u
+
+cmd=$(jq -r '.tool_input.command // ""')
+
+ask() {
+  jq -n --arg reason "$1" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "ask",
+      permissionDecisionReason: $reason
+    }
+  }'
+  exit 0
+}
+
+# Write HTTP method via -X / --method, with optional space or = separator
+# (covers `-X POST`, `-XPOST`, `--method POST`, `--method=POST`).
+if echo "$cmd" | grep -qiE '(-X[[:space:]=]*|--method[[:space:]=]*)(POST|PUT|PATCH|DELETE)\b'; then
+  ask "gh api write method (POST/PUT/PATCH/DELETE) — confirm before sending"
+fi
+
+# graphql endpoint: query vs mutation can't be told without parsing the
+# query body, so prompt for every graphql call.
+if echo "$cmd" | grep -qE '\bgh[[:space:]]+api[[:space:]]+graphql\b'; then
+  ask "gh api graphql can mutate — confirm before sending"
+fi
+
+# Default: silent, defer to permission rules (allow).
+exit 0

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -42,6 +42,7 @@
       "Bash(gh run list:*)",
       "Bash(gh auth:*)",
       "Bash(gh repo view:*)",
+      "Bash(gh api:*)",
       "Bash(direnv:*)",
       "Bash(fish:*)"
     ],
@@ -58,7 +59,6 @@
       "Bash(jj git push:*)",
       "Bash(gh pr create:*)",
       "Bash(gh pr merge:*)",
-      "Bash(gh api:*)",
       "Bash(nix flake update:*)"
     ],
     "defaultMode": "auto"
@@ -72,6 +72,16 @@
           {
             "type": "command",
             "command": "~/.claude/ast-grep-nudge-hook.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/gh-api-write-guard.sh",
+            "if": "Bash(gh api:*)"
           }
         ]
       }


### PR DESCRIPTION
## Goal
Stop prompting for read-only \`gh api\` calls without losing the safety net for write calls.

## Problem
Permission rules are prefix-matched. In \`gh api\` syntax, the endpoint comes first and the HTTP method flag after, so no \`Bash(gh api ...:*)\` rule can distinguish GET vs POST. Without a hook, \`gh api -X POST repos/.../pulls\` would create a PR with no prompt, bypassing the existing \`Bash(gh pr create:*)\` ask rule.

## Solution
Added a PreToolUse hook that returns \`permissionDecision: "ask"\` for \`gh api\` commands containing:
- Write method flags: \`-X POST/PUT/PATCH/DELETE\`, \`--method POST/...\` (with or without \`=\`/space, case-insensitive)
- GraphQL queries: \`gh api graphql\` (conservatively gated since mutations require body parsing)

## Changes
1. **\`claude/gh-api-write-guard.sh\`** — new PreToolUse Bash hook that inspects gh api commands and gates writes
2. **\`claude/settings.json\`** — moves \`Bash(gh api:*)\` from \`permissions.ask\` to \`permissions.allow\` and registers the hook

## Verified
- **Passes (no prompt)**: \`gh api repos/.../pulls/191\`, \`gh api -X GET --paginate ...\`, \`gh api repos/.../pulls -F method=POST\` (form field, not method)
- **Blocks (prompts)**: \`gh api -X POST\`, \`gh api -XPOST\`, \`gh api --method PATCH\`, \`gh api --method=DELETE\`, \`gh api -x post\`, \`gh api graphql -f query=...\`

## Note
Supersedes #191, which had the allow rule without the hook and left a write-through hole.

🤖 Generated with Claude Code