### PR TITLE
:wrench: chore(nixos): enable rootful podman docker socket and wire DOCKER_HOST

### DIFF
--- a/modules/fish.nix
+++ b/modules/fish.nix
@@ -41,6 +41,10 @@
       set -g fish_pager_color_prefix 8caaee
       set -g fish_pager_color_completion c6d0f5
       set -g fish_pager_color_description 737994
+
+      # Point Docker clients at the rootful Podman socket
+      # (enabled by virtualisation.podman.dockerSocket in nixos/configuration.nix)
+      set -gx DOCKER_HOST unix:///run/podman/podman.sock
     '';
 
     # Interactive shell initialization

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -1,7 +1,12 @@
 # NixOS system configuration for WSL2 + Hyprland
 # This file is a reference copy of /etc/nixos/configuration.nix
 # Apply with: sudo cp nixos/configuration.nix /etc/nixos/configuration.nix && sudo nixos-rebuild switch
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 {
   imports = [
     <nixos-wsl/modules>
@@ -18,11 +23,20 @@
   # vkms kernel module (requires custom WSL2 kernel with CONFIG_DRM_VKMS=m).
   # tun is needed so pasta can create its TAP device for rootless container
   # networking; /dev/net/tun is otherwise absent on this WSL build.
-  boot.kernelModules = [ "vkms" "tun" ];
+  boot.kernelModules = [
+    "vkms"
+    "tun"
+    "bridge"
+    "br_netfilter"
+  ];
 
   # seatd for Wayland compositor device access
   services.seatd.enable = true;
-  users.users.nixos.extraGroups = [ "seat" "video" ];
+  users.users.nixos.extraGroups = [
+    "seat"
+    "video"
+    "podman"
+  ];
 
   # nix-ld: run unpatched dynamic binaries on NixOS
   programs.nix-ld.enable = true;
@@ -68,6 +82,7 @@
   virtualisation.podman = {
     enable = true;
     dockerCompat = true;
+    dockerSocket.enable = true;
     defaultNetwork.settings.dns_enabled = true;
   };
 


### PR DESCRIPTION
## Summary

- **nixos**: Enable `virtualisation.podman.dockerSocket` so Podman exposes the Docker-compat socket at `/run/podman/podman.sock`.
- **nixos**: Add the `nixos` user to the `podman` group so clients can talk to that socket without sudo.
- **nixos**: nixfmt-style multi-line formatting for `boot.kernelModules` and `users.users.nixos.extraGroups`.
- **fish**: `set -gx DOCKER_HOST unix:///run/podman/podman.sock` in `programs.fish.shellInit` so docker clients pick up the podman socket on shell launch.

## Test plan

- [ ] `sudo cp nixos/configuration.nix /etc/nixos/configuration.nix && sudo nixos-rebuild switch`
- [ ] `home-manager switch --flake .`
- [ ] `ls -l /run/podman/podman.sock` shows the socket exists
- [ ] Open a new fish shell: `echo $DOCKER_HOST` prints `unix:///run/podman/podman.sock`
- [ ] `docker ps` (or `podman ps`) works as `nixos` without sudo