### PR TITLE
:arrow_up: chore(flake): bump claude-code-overlay, home-manager, nixpkgs, pi.nix inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -33,11 +33,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1781829044,
-        "narHash": "sha256-XS5YlvRDDo+WjK+SUyIP4FvG1Mb2wcYBY4b1jRoorUE=",
+        "lastModified": 1782111423,
+        "narHash": "sha256-W3XvUOjHqyZPg5mK/HtjW0aS8Ko1sQYct6VBiNLR52o=",
         "owner": "ryoppippi",
         "repo": "claude-code-overlay",
-        "rev": "10882a469fb71c2acb6d38fb7d4b2592991f6031",
+        "rev": "3e63dfcebdc85e09c718ce2f0b58c7867bc45636",
         "type": "github"
       },
       "original": {
@@ -107,11 +107,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781837603,
-        "narHash": "sha256-zGIqa68+DxfGlepR07ZK00GaEz2++YlYRRpyJu5WUP4=",
+        "lastModified": 1782103446,
+        "narHash": "sha256-+vMR3KPBVoY9nJrQI9qje5H1vmv51dJgMYkUuYimtJg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0f4a317c06ed69a4b15441490d46cdccd24c98c7",
+        "rev": "d8dac1f668fd861369571be3678ec75b1573e7e3",
         "type": "github"
       },
       "original": {
@@ -122,11 +122,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {
@@ -175,11 +175,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1781803074,
-        "narHash": "sha256-evA6Q8cGuqIaoYtV0KPwyN/qipU3ulKcf9nr6Fp064Y=",
+        "lastModified": 1782080524,
+        "narHash": "sha256-eqY/uXvtE08JXwva1U4bVjQ3WrE54zUGl280FeFJJ0A=",
         "owner": "lukasl-dev",
         "repo": "pi.nix",
-        "rev": "826bd3586bd7b9a3b7189c5e4a2678d892e2d50b",
+        "rev": "b30df12fb44074c0e668fd76a34dcf01ac7a2df8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Routine flake input bumps:

- `claude-code-overlay`: `10882a4` → `3e63dfc`
- `home-manager`: `0f4a317` → `d8dac1f`
- `nixpkgs`: `64c08a7` → `567a49d`
- `pi.nix`: `826bd35` → `b30df12`

## Test plan

- [ ] `nix flake check`
- [ ] `home-manager switch --flake .` succeeds on `nixos@wsl`
- [ ] Shell + WezTerm launch cleanly, claude-code overlay still resolves