### PR TITLE
:sparkles: feat(home): add wireguard-tools

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -54,6 +54,9 @@ in
     gzip # Compression tool
     rsync # File sync
 
+    # Networking
+    wireguard-tools # WireGuard VPN CLI (wg, wg-quick)
+
     # Development tools
     git-lfs # Git Large File Storage
     gh # GitHub CLI


### PR DESCRIPTION
## Summary

- Adds `wireguard-tools` to `home.packages`, exposing `wg`, `wg-quick`, and `wg-show` on PATH.
- Lives under a new "Networking" subsection in `home.nix` to keep the package list semantically grouped.

## Notes

- This adds **CLI tools only** — no managed tunnel. To bring up a connection, drop a config at `/etc/wireguard/<name>.conf` and run `sudo wg-quick up <name>`.
- A NixOS-managed always-on tunnel would go in `nixos/configuration.nix` under `networking.wireguard.interfaces.*`, which is a separate concern (and requires real keys/peer info).
- WSL2's stock kernel already ships WireGuard, so no kernel module work is needed.

## Test plan

- [x] `nix flake check` passes
- [x] `home-manager switch --flake .#nixos@wsl` succeeds
- [x] `wg --version` → `wireguard-tools v1.0.20260223`
- [x] `wg-quick` resolves on PATH