### PR TITLE
:sparkles: feat(wezterm): add ssh mux domain for cross-machine session sharing

### DIFF
--- a/modules/wezterm.nix
+++ b/modules/wezterm.nix
@@ -14,6 +14,7 @@
   xdg.configFile."wezterm/fonts.lua".source = ../wezterm/fonts.lua;
   xdg.configFile."wezterm/keybindings.lua".source = ../wezterm/keybindings.lua;
   xdg.configFile."wezterm/mouse.lua".source = ../wezterm/mouse.lua;
+  xdg.configFile."wezterm/mux.lua".source = ../wezterm/mux.lua;
   xdg.configFile."wezterm/performance.lua".source = ../wezterm/performance.lua;
   xdg.configFile."wezterm/platform.lua".source = ../wezterm/platform.lua;
   xdg.configFile."wezterm/tabline.lua".source = ../wezterm/tabline.lua;

--- a/wezterm/domains.lua
+++ b/wezterm/domains.lua
@@ -17,8 +17,9 @@ function M.apply(config)
     config.default_prog = { shell.fish_path }
   end
 
-  -- Launch menu (platform-specific)
-  config.launch_menu = {}
+  -- Launch menu (platform-specific). Preserve any entries other modules
+  -- may have appended, so this apply() is load-order agnostic.
+  config.launch_menu = config.launch_menu or {}
 
   if platform.is_windows then
     table.insert(config.launch_menu, {

--- a/wezterm/keybindings.lua
+++ b/wezterm/keybindings.lua
@@ -107,6 +107,17 @@ function M.apply(config)
     },
 
     -- ============================================
+    -- Remote mux (LEADER + key)
+    -- ============================================
+
+    -- Attach to the remote wezterm mux
+    {
+      key = 'm',
+      mods = 'LEADER',
+      action = wezterm.action.AttachDomain 'mux:wez-mux',
+    },
+
+    -- ============================================
     -- Utility operations (LEADER + key)
     -- ============================================
 

--- a/wezterm/mux.lua
+++ b/wezterm/mux.lua
@@ -1,0 +1,33 @@
+-- Remote multiplexer domains (cross-machine wezterm session sharing).
+--
+-- Contract: an ssh_config alias named MUX_SSH_ALIAS below must exist on
+-- each client machine's OS-level ssh config (Windows: %USERPROFILE%\.ssh\config,
+-- Linux/macOS: ~/.ssh/config). It must resolve HostName / User / IdentityFile
+-- for the target Linux server. Real host details are per-machine and NOT
+-- committed to this repo.
+
+local M = {}
+
+local MUX_SSH_ALIAS = 'wez-mux'
+local MUX_NAME      = 'mux:wez-mux'
+
+function M.apply(config)
+  config.ssh_domains = config.ssh_domains or {}
+  table.insert(config.ssh_domains, {
+    name           = MUX_NAME,
+    remote_address = MUX_SSH_ALIAS,
+    multiplexing   = 'WezTerm',
+    assume_shell   = 'Posix',
+    -- username taken from ssh_config
+  })
+
+  config.launch_menu = config.launch_menu or {}
+  table.insert(config.launch_menu, {
+    label = 'Attach: ' .. MUX_NAME,
+    args  = { 'wezterm', 'connect', MUX_NAME },
+  })
+end
+
+M.name = MUX_NAME
+
+return M

--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -15,6 +15,7 @@ require('appearance').apply(config)
 require('keybindings').apply(config)
 require('mouse').apply(config)
 require('domains').apply(config)
+require('mux').apply(config)
 require('performance').apply(config)
 
 -- Load tabline plugin (must be loaded after other configurations)


### PR DESCRIPTION
## Summary

- Adds `wezterm/mux.lua`: an SSH multiplexer domain for cross-machine wezterm session sharing.
- New keybinding `LEADER + m` (`Ctrl+Space` then `m`) attaches to the domain; also exposed in the launcher as `Attach: mux:wez-mux`.
- Wired into `wezterm/wezterm.lua`, `wezterm/keybindings.lua`, and `modules/wezterm.nix`.
- Hardens `wezterm/domains.lua` so its `launch_menu` initialization is load-order agnostic (no more silent clobber of entries other modules append).
- No secrets committed. Real hostname / user / IdentityFile live per-machine under the ssh_config alias `wez-mux`.

## Design rationale

- SSH domain with `multiplexing = 'WezTerm'` — client spawns `wezterm-mux-server --daemonize` on the remote via SSH. Mux persists across client disconnects.
- Both `mux.lua` and `domains.lua` now use `config.launch_menu = config.launch_menu or {}`, so require-order in `wezterm.lua` no longer determines whether the `Attach: mux:wez-mux` launcher entry survives.
- Keybinding uses the existing LEADER convention rather than a raw `Ctrl+Shift+M` so it matches the codebase's shortcut style.
- Windows-side wezterm reads this config through a `\\wsl$\...` UNC symlink, so all the client changes land automatically once Home Manager symlinks the module into `~/.config/wezterm/`.

## Reboot-durability (follow-up, not shipped in this PR)

The client-side mux domain daemonizes the mux server on connect, so state survives client disconnects but not a remote reboot. To make it survive reboots, deploy on the remote (one-time):

1. `~/.config/systemd/user/wezterm-mux.service`:
   ```
   [Unit]
   Description=WezTerm multiplexer server
   After=default.target

   [Service]
   Type=forking
   ExecStart=%h/.nix-profile/bin/wezterm-mux-server --daemonize
   Restart=on-failure

   [Install]
   WantedBy=default.target
   ```
   (Adjust `ExecStart` if wezterm is not on `$PATH` at that location.)
2. `systemctl --user daemon-reload && systemctl --user enable --now wezterm-mux.service`
3. As root, once per user: `sudo loginctl enable-linger $USER` so the user service survives logout / SSH session end.

After this, `LEADER + m` will find an already-running mux across reboots. No changes needed on the client side.

## Per-machine setup

On each client machine, add to the OS-level ssh_config (Windows: `%USERPROFILE%\.ssh\config`; Linux/macOS: `~/.ssh/config`):

```
Host wez-mux
  HostName <real host>
  User <remote user>
  IdentityFile ~/.ssh/<key>
```

Windows wezterm uses Windows OpenSSH's ssh_config, NOT the WSL one — this is easy to miss.

## Test plan

- [x] `nix flake check` — passes.
- [x] Plain-Lua module load check — `mux.lua` exports `M.apply` and `M.name == 'mux:wez-mux'`.
- [x] `home-manager switch --flake .#nixos@wsl` — applies cleanly. `~/.config/wezterm/mux.lua` symlink resolves to the Nix store copy with identical contents.
- [ ] **Interactive (deferred to reviewer / merger):**
  - [ ] Add `Host wez-mux` block to Windows-side `%USERPROFILE%\.ssh\config`; confirm `ssh wez-mux` from a Windows terminal reaches the remote.
  - [ ] Reload wezterm (`LEADER + r`); confirm no red toast.
  - [ ] Open launcher (`LEADER + Space`); confirm `Attach: mux:wez-mux` entry appears.
  - [ ] Press `LEADER + m`; confirm a new tab attaches to the remote shell.
  - [ ] Persistence test: `nohup sh -c 'while sleep 1; do date; done' > /tmp/mux-heartbeat.log 2>&1 &`, close wezterm, reopen, `LEADER + m`, `tail -f /tmp/mux-heartbeat.log` shows continuous timestamps. Kill the heartbeat after.
