### PR TITLE
:sparkles: feat(home): add llama.cpp local LLM inference engine

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -60,6 +60,7 @@ in
     ghq # Git repository manager
     claude-code # Claude AI coding assistant (native binary via ryoppippi/claude-code-overlay)
     pi-coding-agent # Pi coding agent (native binary via lukasl-dev/pi.nix; Codex/Claude/Copilot subscription login)
+    llama-cpp # Local LLM inference engine (llama-cli, llama-server for GGUF models)
 
     # Containers
     podman # Daemonless container engine (docker-compatible CLI)


### PR DESCRIPTION
## Summary
- Add `llama-cpp` to `home.packages`, providing `llama-cli` and `llama-server` for running local GGUF models.

## Verification
- `home-manager switch --flake .#nixos@wsl` succeeds.
- `llama-cli --version` → `version: 9608 (70b54e1)`; binaries resolve under `~/.nix-profile/bin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)