### PR TITLE
:sparkles: feat(pi): serve Bonsai 27B locally via llama-server

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -16,6 +16,7 @@ in
     ./modules/common.nix
     ./modules/claude-code.nix
     ./modules/pi.nix
+    ./modules/llama-cpp.nix
     ./modules/hyprland.nix
   ];
 

--- a/modules/llama-cpp.nix
+++ b/modules/llama-cpp.nix
@@ -1,0 +1,41 @@
+{ pkgs, lib, ... }:
+
+let
+  # Prism ML Bonsai 27B ternary quant. llama-server's -hf flag lazily
+  # downloads the GGUF into ~/.cache/llama.cpp on first launch and reuses it
+  # thereafter, so we don't need a Nix-managed weights derivation.
+  hfRepo = "prism-ml/Ternary-Bonsai-27B-gguf";
+  hfQuant = "Q2_0";
+  host = "127.0.0.1";
+  port = 8080;
+in
+{
+  # Local Bonsai 27B inference exposed as an OpenAI-compatible endpoint at
+  # http://127.0.0.1:8080/v1. Pi's local-llama provider (see modules/pi.nix)
+  # points at this service.
+  systemd.user.services.llama-server = {
+    Unit = {
+      Description = "llama.cpp OpenAI-compatible server (Bonsai 27B)";
+      Documentation = [ "https://github.com/ggml-org/llama.cpp" ];
+      After = [ "network-online.target" ];
+      Wants = [ "network-online.target" ];
+    };
+
+    Service = {
+      Type = "simple";
+      ExecStart = lib.concatStringsSep " " [
+        "${pkgs.llama-cpp}/bin/llama-server"
+        "-hf ${hfRepo}:${hfQuant}"
+        "--host ${host}"
+        "--port ${toString port}"
+        "-c 0"
+        "--jinja"
+        "--alias bonsai-27b"
+      ];
+      Restart = "on-failure";
+      RestartSec = 5;
+    };
+
+    Install.WantedBy = [ "default.target" ];
+  };
+}

--- a/modules/pi.nix
+++ b/modules/pi.nix
@@ -65,15 +65,19 @@
     fi
   '';
 
-  # Pi reads context-window metadata from models.json. The OpenAI Codex
-  # GPT-5.4/GPT-5.5 models default to 272K in pi's bundled metadata, but can use
-  # the experimental 1M-token context window. Merge the override so any existing
-  # custom providers or model settings remain intact.
+  # Pi reads context-window metadata and custom providers from models.json.
+  # Two overrides are merged here so they don't race on the same file:
+  #   1. Bump the OpenAI Codex GPT-5.4/GPT-5.5 context window from pi's default
+  #      272K to the experimental 1M-token window.
+  #   2. Register a `local-llama` provider that points at the llama-server user
+  #      service (see modules/llama-cpp.nix) serving Bonsai 27B as an
+  #      OpenAI-compatible endpoint on 127.0.0.1:8080.
+  # Existing custom providers or model settings are preserved.
   home.activation.setPiCodexContextWindow = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
         models="$HOME/.pi/agent/models.json"
 
         if [ -n "''${DRY_RUN:-}" ]; then
-          echo "Would update $models with 1M OpenAI Codex context-window overrides"
+          echo "Would update $models with 1M OpenAI Codex context-window overrides and local-llama provider"
         else
           mkdir -p "$HOME/.pi/agent"
 
@@ -115,6 +119,18 @@
         contextWindow: 1000000,
       };
     }
+
+    const existingLocal = config.providers["local-llama"];
+    const localBase = (existingLocal && typeof existingLocal === "object" && !Array.isArray(existingLocal)) ? existingLocal : {};
+    const existingModels = Array.isArray(localBase.models) ? localBase.models : [];
+    const hasBonsai = existingModels.some((m) => m && typeof m === "object" && m.id === "bonsai-27b");
+    config.providers["local-llama"] = {
+      ...localBase,
+      api: "openai-completions",
+      apiKey: "local",
+      baseUrl: "http://127.0.0.1:8080/v1",
+      models: hasBonsai ? existingModels : [...existingModels, { id: "bonsai-27b" }],
+    };
 
     writeFileSync(modelsPath + ".tmp", JSON.stringify(config, null, 2) + "\n");
     NODE


### PR DESCRIPTION
## Summary
- Adds `modules/llama-cpp.nix`: user-level `llama-server.service` that serves Prism ML's Bonsai 27B (Ternary Q2_0 GGUF) at `http://127.0.0.1:8080` via llama.cpp's OpenAI-compatible API. Weights are lazy-fetched into `~/.cache/llama.cpp/` on first launch; `--jinja` enables the model's own chat template so tool calling works.
- Wires the module into `home.nix`.
- Extends the existing pi `setPiCodexContextWindow` merge in `modules/pi.nix` to also register a `local-llama` provider (openai-completions, `bonsai-27b` model) in `~/.pi/agent/models.json`. The existing Codex 1M-token override and any user-added providers are preserved.

Use with:
`pi --provider local-llama --model bonsai-27b`

## Test plan
- [x] `nix flake check --no-build` passes
- [x] `home-manager switch --flake .#nixos@wsl` applies cleanly and starts `llama-server.service`
- [x] `systemctl --user status llama-server.service` shows Active: running
- [x] `~/.pi/agent/models.json` contains both `openai-codex.modelOverrides` and the new `local-llama` provider
- [ ] After the first-run HF download completes, `curl http://127.0.0.1:8080/v1/models` returns `bonsai-27b` and `pi --provider local-llama --model bonsai-27b -p "hi"` responds