### PR TITLE
:sparkles: feat(home): add hunk terminal diff viewer with jj + Claude Code integration

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -18,6 +18,7 @@ in
     ./modules/pi.nix
     ./modules/llama-cpp.nix
     ./modules/hyprland.nix
+    ./modules/hunk.nix
   ];
 
   # Let Home Manager manage itself

--- a/modules/hunk.nix
+++ b/modules/hunk.nix
@@ -1,0 +1,18 @@
+{ pkgs, ... }:
+
+{
+  home.packages = with pkgs; [
+    hunk # Terminal diff viewer for agent-authored changesets (git/jj/sl aware)
+  ];
+
+  # This environment's VCS is Jujutsu (see modules/jujutsu.nix), not git.
+  xdg.configFile."hunk/config.toml".text = ''
+    vcs = "jj"
+  '';
+
+  # Expose hunk's bundled review skill to Claude Code as a personal-scope skill
+  # (~/.claude/skills/<name>/SKILL.md is auto-discovered and symlinks are
+  # followed) so Claude Code can drive a live `hunk` session via
+  # `hunk session ...` while coding.
+  home.file.".claude/skills/hunk-review".source = "${pkgs.hunk}/skills/hunk-review";
+}


### PR DESCRIPTION
## Summary

- Package `hunk` (terminal diff viewer from https://github.com/modem-dev/hunk) as a Home Manager module (`modules/hunk.nix`)
- Configure hunk to use Jujutsu as its VCS (set `vcs = "jj"` in `~/.config/hunk/config.toml`), since this environment uses jj, not git
- Symlink hunk's bundled `hunk-review` skill into `~/.claude/skills/hunk-review` as a personal-scope Claude Code skill (auto-discovered, symlink-following per Claude Code docs), enabling Claude Code to drive interactive `hunk` sessions via `hunk session ...` commands while coding
- Bump the `nixpkgs` flake input: the previously-pinned revision predated hunk's addition to nixpkgs. This also carries forward an in-flight nixpkgs bump that was already uncommitted.

### Design Note

This approach diverges from the repo's existing marketplace-plugin pattern (used for jj-master and architect skills) in favor of a simpler, self-updating personal-scope skill symlink. Reviewers may want to weigh in on this design choice.

### Home Manager Deprecation Warnings

The nixpkgs bump surfaces two pre-existing (unrelated to this PR) Home Manager deprecation warnings:
- `programs.ssh.matchBlocks` (legacy format)
- `programs.neovim.withRuby`/`withPython3` (legacy overlay syntax)

These are not introduced by this change, just newly visible with the newer nixpkgs revision.

## Test Plan

- ✓ `nix flake check` passed
- ✓ `home-manager switch --flake .#nixos@wsl` applied cleanly
- ✓ Verified `hunk --version` (0.17.0) on PATH
- ✓ Verified `~/.config/hunk/config.toml` contains `vcs = "jj"`
- ✓ Verified `~/.claude/skills/hunk-review` resolves through the nix store to a readable SKILL.md